### PR TITLE
콘서트 예매 시스템 기본 API 구축

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,20 +30,21 @@ dependencyManagement {
 }
 
 dependencies {
-    // Spring
+	// Spring
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 
-    // DB
+	// DB
 	runtimeOnly("com.mysql:mysql-connector-j")
 
-    // Test
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
+	// Test
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.boot:spring-boot-testcontainers")
 	testImplementation("org.testcontainers:junit-jupiter")
 	testImplementation("org.testcontainers:mysql")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	// TestContainer
 
 	// Lombok
 	compileOnly("org.projectlombok:lombok")
@@ -52,8 +53,17 @@ dependencies {
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 
 	// Mock
-	testImplementation("com.squareup.okhttp3:okhttp:4.10.0")
-	testImplementation("com.squareup.okhttp3:mockwebserver:4.11.0")
+	//testImplementation("com.squareup.okhttp3:okhttp:4.10.0")
+	//testImplementation("com.squareup.okhttp3:mockwebserver:4.11.0")
+
+	//Swagger
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
+
+	// QueryDSL
+
+	// Jakarta Bean Validation API
+	implementation("org.springframework.boot:spring-boot-starter-validation")
+
 }
 
 tasks.withType<Test> {

--- a/src/main/java/kr/hhplus/be/server/ServerApplication.java
+++ b/src/main/java/kr/hhplus/be/server/ServerApplication.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 public class ServerApplication {

--- a/src/main/java/kr/hhplus/be/server/api/balance/application/service/BalanceService.java
+++ b/src/main/java/kr/hhplus/be/server/api/balance/application/service/BalanceService.java
@@ -1,0 +1,76 @@
+package kr.hhplus.be.server.api.balance.application.service;
+
+import kr.hhplus.be.server.api.balance.domain.entity.Balance;
+import kr.hhplus.be.server.api.balance.exception.BalanceErrorCode;
+import kr.hhplus.be.server.api.balance.infrastructure.BalanceRepository;
+import kr.hhplus.be.server.api.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+public class BalanceService {
+
+    private final BalanceRepository balanceRepository;
+
+    /**
+     * 사용자 잔액을 조회
+     * - 사용자가 존재하지 않을 경우 기본값 0을 반환
+     */
+    @Transactional(readOnly = true)
+    public Long getBalance(Long userId) {
+        // 사용자 잔액 조회
+        return balanceRepository.findByUserId(userId)
+                // 잔액 정보가 없으면 0 반환
+                .map(Balance::getBalance)
+                .orElse(0L);
+    }
+    
+    /**
+     * 사용자 잔액을 충전 후, 현재 잔액 반환
+     * @param amount 충전 금액
+     */
+    @Transactional
+    public Long chargeBalance(Long userId, Long amount) {
+        // 사용자 잔액 조회
+        Balance balance = balanceRepository.findByUserId(userId)
+                // 잔액 정보가 없으면 새로운 Balance 객체 생성
+                .orElse(Balance.builder()
+                        .userId(userId)
+                        .balance(0L) // 초기 잔액 0으로 설정
+                        .build());
+
+        // 잔액 충전
+        balance.addAmount(amount);
+
+        // 변경된 잔액 정보 저장
+        balanceRepository.save(balance);
+
+        // 충전 후의 현재 잔액 반환
+        return balance.getBalance();
+    }
+
+    /**
+     * 사용자 잔액 차감
+     * @param amount 차감 금액
+     */
+    @Transactional
+    public void deductBalance(Long userId, Long amount) {
+        // 사용자 잔액 조회
+        Balance balance = balanceRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(BalanceErrorCode.BALANCE_NOT_FOUND));
+
+        // 잔액 부족 여부 확인
+        if (balance.getBalance().compareTo(amount) < 0) {
+            throw new CustomException(BalanceErrorCode.BALANCE_INSUFFICIENT);
+        }
+        // 잔액 차감
+        balance.deductAmount(amount);
+
+        // 차감 된 잔액 정보 저장
+        balanceRepository.save(balance);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/balance/domain/entity/Balance.java
+++ b/src/main/java/kr/hhplus/be/server/api/balance/domain/entity/Balance.java
@@ -1,0 +1,36 @@
+package kr.hhplus.be.server.api.balance.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Balance {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long userId;
+
+    @Column
+    private Long balance; // 확장 될 경우 BigDecimal 사용
+
+    public void addAmount(Long chargeAmount) {
+        this.balance += chargeAmount;
+    }
+
+    public void deductAmount(Long deductAmount) {
+        this.balance -= deductAmount;
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/api/balance/domain/entity/User.java
+++ b/src/main/java/kr/hhplus/be/server/api/balance/domain/entity/User.java
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.api.balance.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+}

--- a/src/main/java/kr/hhplus/be/server/api/balance/exception/BalanceErrorCode.java
+++ b/src/main/java/kr/hhplus/be/server/api/balance/exception/BalanceErrorCode.java
@@ -1,0 +1,23 @@
+package kr.hhplus.be.server.api.balance.exception;
+
+import kr.hhplus.be.server.api.common.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum BalanceErrorCode implements ErrorCode {
+    BALANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "BALANCE_NOT_FOUND", "잔액 정보를 찾을 수 없습니다."),
+    BALANCE_INSUFFICIENT(HttpStatus.BAD_REQUEST, "BALANCE_INSUFFICIENT", "잔액이 부족합니다."),
+    BALANCE_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "BALANCE_UPDATE_FAILED", "잔액 업데이트에 실패했습니다."),
+    BALANCE_LOCK_FAILED(HttpStatus.CONFLICT, "BALANCE_LOCK_FAILED", "잔액 잠금 처리에 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String name;
+    private final String message;
+
+    BalanceErrorCode(HttpStatus httpStatus, String name, String message) {
+        this.httpStatus = httpStatus;
+        this.name = name;
+        this.message = message;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/balance/infrastructure/BalanceRepository.java
+++ b/src/main/java/kr/hhplus/be/server/api/balance/infrastructure/BalanceRepository.java
@@ -1,0 +1,12 @@
+package kr.hhplus.be.server.api.balance.infrastructure;
+
+import kr.hhplus.be.server.api.balance.domain.entity.Balance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BalanceRepository extends JpaRepository<Balance, String> {
+    Optional<Balance> findByUserId(Long userId);
+}

--- a/src/main/java/kr/hhplus/be/server/api/balance/presentation/controller/BalanceController.java
+++ b/src/main/java/kr/hhplus/be/server/api/balance/presentation/controller/BalanceController.java
@@ -1,0 +1,51 @@
+package kr.hhplus.be.server.api.balance.presentation.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.hhplus.be.server.api.balance.application.service.BalanceService;
+import kr.hhplus.be.server.api.balance.presentation.dto.BalanceResponse;
+import kr.hhplus.be.server.api.balance.presentation.dto.ChargeRequest;
+import kr.hhplus.be.server.api.common.response.ApiResponse;
+import kr.hhplus.be.server.api.common.response.dto.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/users/balance")
+@RequiredArgsConstructor
+@Tag(name = "User Balance", description =  "사용자 잔액 API - 잔액 조회 및 충전")
+public class BalanceController {
+
+    private final BalanceService balanceService;
+
+    /**
+     * 잔액 조회 API
+     * @param userId
+     * @return 사용자 잔액 정보
+     */
+    @GetMapping("/{userId}")
+    public ResponseEntity<ResponseDTO<BalanceResponse>> getBalance(@PathVariable Long userId) {
+        Long amount = balanceService.getBalance(userId);
+
+        BalanceResponse response = new BalanceResponse(userId, amount);
+
+        return ApiResponse.success("잔액 조회 성공", response);
+    }
+
+    /**
+     * 잔액 충전 API
+     * @param request
+     * @return 성공 메시지
+     */
+    @PostMapping("/charge")
+    public ResponseEntity<ResponseDTO<BalanceResponse>> rechargeBalance(@RequestBody ChargeRequest request) {
+        // 충전 후의 현재 잔액 계산
+        Long updatedAmount = balanceService.chargeBalance(request.getUserId(), request.getAmount());
+
+        BalanceResponse response = new BalanceResponse(request.getUserId(), updatedAmount);
+
+        return ApiResponse.success("잔액이 충전되었습니다.", response);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/balance/presentation/dto/BalanceResponse.java
+++ b/src/main/java/kr/hhplus/be/server/api/balance/presentation/dto/BalanceResponse.java
@@ -1,0 +1,15 @@
+package kr.hhplus.be.server.api.balance.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class BalanceResponse {
+    private Long userId;
+    private Long amount;
+}

--- a/src/main/java/kr/hhplus/be/server/api/balance/presentation/dto/ChargeRequest.java
+++ b/src/main/java/kr/hhplus/be/server/api/balance/presentation/dto/ChargeRequest.java
@@ -1,0 +1,9 @@
+package kr.hhplus.be.server.api.balance.presentation.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ChargeRequest {
+    private Long userId;
+    private Long amount;
+}

--- a/src/main/java/kr/hhplus/be/server/api/common/config/SwaggerConfig.java
+++ b/src/main/java/kr/hhplus/be/server/api/common/config/SwaggerConfig.java
@@ -1,0 +1,21 @@
+package kr.hhplus.be.server.api.common.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .version("v1.0") //버전
+                .title("콘서트 예약 시스템 API") //이름
+                .description("콘서트 예약 시스템 API"); //설명
+        return new OpenAPI()
+                .info(info);
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/api/common/config/WebConfig.java
+++ b/src/main/java/kr/hhplus/be/server/api/common/config/WebConfig.java
@@ -1,0 +1,21 @@
+package kr.hhplus.be.server.api.common.config;
+
+import kr.hhplus.be.server.api.token.infrastructure.TokenInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final TokenInterceptor tokenInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(tokenInterceptor)
+                .addPathPatterns("/concerts/**, /reservations/**") // 경로 지정
+                .excludePathPatterns("/public/**") // 특정 경로 제외
+                ;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/common/exception/CustomException.java
+++ b/src/main/java/kr/hhplus/be/server/api/common/exception/CustomException.java
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.api.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return errorCode.getHttpStatus();
+    }
+
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/common/exception/ErrorCode.java
+++ b/src/main/java/kr/hhplus/be/server/api/common/exception/ErrorCode.java
@@ -1,0 +1,9 @@
+package kr.hhplus.be.server.api.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getHttpStatus();
+    String getMessage();
+    String getName();
+}

--- a/src/main/java/kr/hhplus/be/server/api/common/exception/ErrorResponse.java
+++ b/src/main/java/kr/hhplus/be/server/api/common/exception/ErrorResponse.java
@@ -1,0 +1,11 @@
+package kr.hhplus.be.server.api.common.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ErrorResponse {
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/kr/hhplus/be/server/api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/hhplus/be/server/api/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package kr.hhplus.be.server.api.common.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 전역 예외 처리 핸들러
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode().getName(), e.getMessage());
+        return ResponseEntity.status(e.getHttpStatus()).body(errorResponse);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/common/response/ApiResponse.java
+++ b/src/main/java/kr/hhplus/be/server/api/common/response/ApiResponse.java
@@ -1,0 +1,15 @@
+package kr.hhplus.be.server.api.common.response;
+
+import kr.hhplus.be.server.api.common.response.dto.ResponseDTO;
+import org.springframework.http.ResponseEntity;
+
+public class ApiResponse {
+
+    public static <T> ResponseEntity<ResponseDTO<T>> success(String message, T data) {
+        return ResponseEntity.ok(new ResponseDTO<>(true, message, data));
+    }
+
+    public static ResponseEntity<ResponseDTO<Object>> error(String errorName, String message) {
+        return ResponseEntity.badRequest().body(new ResponseDTO<>(false, errorName + ": " + message, null));
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/common/response/dto/ResponseDTO.java
+++ b/src/main/java/kr/hhplus/be/server/api/common/response/dto/ResponseDTO.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.api.common.response.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor
+public class ResponseDTO<T> {
+    private final boolean success; // 요청 성공 여부 (true: 성공, false: 실패)
+    private final String message;  // 응답 메시지
+    private final T data;          // 응답 데이터 (성공 시 데이터 객체, 실패 시 null)
+}

--- a/src/main/java/kr/hhplus/be/server/api/common/response/dto/ResponseDTO.java
+++ b/src/main/java/kr/hhplus/be/server/api/common/response/dto/ResponseDTO.java
@@ -1,8 +1,6 @@
 package kr.hhplus.be.server.api.common.response.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 @Data

--- a/src/main/java/kr/hhplus/be/server/api/common/type/ReservationStatus.java
+++ b/src/main/java/kr/hhplus/be/server/api/common/type/ReservationStatus.java
@@ -1,0 +1,6 @@
+package kr.hhplus.be.server.api.common.type;
+
+public enum ReservationStatus {
+    PENDING, //대기중(좌석 예약만 한 상태)
+    PAID, //예약 확정(결제까지 진행 한 상태)
+}

--- a/src/main/java/kr/hhplus/be/server/api/common/type/SeatStatus.java
+++ b/src/main/java/kr/hhplus/be/server/api/common/type/SeatStatus.java
@@ -1,0 +1,6 @@
+package kr.hhplus.be.server.api.common.type;
+
+public enum SeatStatus {
+    AVAILABLE,  // 예약 가능
+    RESERVED,   // 예약됨
+}

--- a/src/main/java/kr/hhplus/be/server/api/common/type/TokenStatus.java
+++ b/src/main/java/kr/hhplus/be/server/api/common/type/TokenStatus.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.api.common.type;
+
+public enum TokenStatus {
+    PENDING,    // 대기열에서 대기 중
+    ACTIVE,     // 작업 완료 또는 활성 상태
+    EXPIRED,    // 만료된 상태
+}

--- a/src/main/java/kr/hhplus/be/server/api/concert/application/dto/AvailableDate.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/application/dto/AvailableDate.java
@@ -1,0 +1,18 @@
+package kr.hhplus.be.server.api.concert.application.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * 예매 가능한 날짜 데이터(Model)
+ */
+public class AvailableDate {
+    private LocalDateTime scheduleDate;
+
+    public AvailableDate(LocalDateTime scheduleDate) {
+        this.scheduleDate = scheduleDate;
+    }
+
+    public LocalDateTime getScheduleDate() {
+        return scheduleDate;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/concert/application/dto/AvailableSeat.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/application/dto/AvailableSeat.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.api.concert.application.dto;
+
+/**
+ * 예매 가능한 좌석 데이터(Model)
+ */
+public class AvailableSeat {
+    private int seatNumber;
+
+    public AvailableSeat(int seatNumber) {
+        this.seatNumber = seatNumber;
+    }
+
+    public int getSeatNumber() {
+        return seatNumber;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/concert/application/service/ConcertService.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/application/service/ConcertService.java
@@ -1,0 +1,95 @@
+package kr.hhplus.be.server.api.concert.application.service;
+
+import kr.hhplus.be.server.api.common.exception.CustomException;
+import kr.hhplus.be.server.api.common.type.SeatStatus;
+import kr.hhplus.be.server.api.concert.domain.entity.ConcertSchedule;
+import kr.hhplus.be.server.api.concert.domain.entity.Seat;
+import kr.hhplus.be.server.api.concert.domain.repository.ConcertScheduleRepository;
+import kr.hhplus.be.server.api.concert.exception.ConcertErrorCode;
+import kr.hhplus.be.server.api.concert.exception.SeatErrorCode;
+import kr.hhplus.be.server.api.concert.domain.repository.SeatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ConcertService {
+    private final ConcertScheduleRepository concertScheduleRepository;
+    private final SeatRepository seatRepository;
+
+    /**
+     * 특정 콘서트의 예매 가능한 날짜 조회
+     */
+    public List<LocalDate> getAvailableDateList(Long concertId){
+        return concertScheduleRepository.findByConcertIdAndIsSoldOut(concertId, false)
+                .stream()
+                .map(ConcertSchedule::getScheduleDate) // 콘서트 일정
+                .distinct()                       // 중복 제거
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 특정 날짜의 예매 가능한 좌석 조회
+     */
+    public List<Integer> getAvailableSeatList(Long concertId, LocalDate scheduleDate) {
+        return seatRepository.findAvailableSeatList(concertId, scheduleDate)
+                .stream()
+                .map(Seat::getSeatNumber)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 좌석 예약
+     */
+    @Transactional
+    public Seat reserveSeat(Long concertId, LocalDate scheduleDate, int seatNumber) {
+        // 매진 여부 확인
+        Optional<Boolean> result  = concertScheduleRepository.isScheduleSoldOut(concertId, scheduleDate);
+        boolean isSoldOut = result.orElse(false); // 기본값으로 false 처리
+        if (isSoldOut) {
+            throw new CustomException(ConcertErrorCode.CONCERT_FULL);
+        }
+
+        // 좌석 상태 확인
+        Seat seat = seatRepository.findSeat(concertId, scheduleDate, seatNumber)
+                .orElseThrow(() -> new CustomException(SeatErrorCode.SEAT_NOT_FOUND));
+
+        if (seat.getStatus() == SeatStatus.RESERVED) {
+            throw new CustomException(SeatErrorCode.SEAT_ALREADY_RESERVED);
+        }
+
+        // 좌석 상태 변경(예약됨)
+        Seat updatedSeat = seat.toBuilder()
+                .status(SeatStatus.RESERVED)
+                .build();
+        seatRepository.save(updatedSeat);
+
+        // 콘서트 매진 상태 업데이트 확인
+        checkAndMarkSoldOut(concertId, scheduleDate);
+
+        return updatedSeat;
+    }
+
+    public void checkAndMarkSoldOut(Long concertId, LocalDate scheduleDate) {
+        // 남은 예약 가능한 좌석 개수 확인
+        long availableSeats = seatRepository.countAvailableSeats(concertId, scheduleDate);
+
+        // 모든 좌석이 예약된 경우 매진 처리
+        if (availableSeats == 0) {
+            ConcertSchedule concertSchedule = concertScheduleRepository.findSchedule(concertId, scheduleDate)
+                    .orElseThrow(() -> new CustomException(ConcertErrorCode.CONCERT_NOT_FOUND));
+
+            ConcertSchedule updatedSchedule = concertSchedule.toBuilder()
+                    .isSoldOut(true) // 매진 처리
+                    .build();
+
+            concertScheduleRepository.save(updatedSchedule);
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/concert/domain/entity/Concert.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/domain/entity/Concert.java
@@ -1,0 +1,19 @@
+package kr.hhplus.be.server.api.concert.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Concert {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+}

--- a/src/main/java/kr/hhplus/be/server/api/concert/domain/entity/ConcertSchedule.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/domain/entity/ConcertSchedule.java
@@ -1,0 +1,27 @@
+package kr.hhplus.be.server.api.concert.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name="concert_schedule")
+public class ConcertSchedule {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long concertId; //논리적 연결(물리적 연결 제외)
+    private LocalDate scheduleDate; // 콘서트(스케줄) 날짜
+
+    @Builder.Default
+    private boolean isSoldOut = false; // 매진 여부
+}

--- a/src/main/java/kr/hhplus/be/server/api/concert/domain/entity/Seat.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/domain/entity/Seat.java
@@ -1,0 +1,35 @@
+package kr.hhplus.be.server.api.concert.domain.entity;
+
+import jakarta.persistence.*;
+import kr.hhplus.be.server.api.common.type.SeatStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/**
+ * Desc : 특정 콘서트의 특정 일정에서 좌석 정보를 나타낸다.
+ */
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class Seat {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int seatNumber; // 좌석 번호
+
+    private Long concertId; // 해당 좌석이 속한 콘서트
+    private LocalDate scheduleDate; // 해당 좌석이 속한 일정
+
+    @Enumerated(EnumType.STRING)
+    private SeatStatus status; // 좌석 상태
+
+    private Long price; // 좌석 금액ㅇ
+}

--- a/src/main/java/kr/hhplus/be/server/api/concert/domain/repository/ConcertScheduleRepository.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/domain/repository/ConcertScheduleRepository.java
@@ -1,0 +1,23 @@
+package kr.hhplus.be.server.api.concert.domain.repository;
+
+import kr.hhplus.be.server.api.concert.domain.entity.ConcertSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ConcertScheduleRepository extends JpaRepository<ConcertSchedule, Long> {
+    List<ConcertSchedule> findByConcertIdAndIsSoldOut(Long concertId, boolean isSoldOut);
+
+    @Query("SELECT cs FROM ConcertSchedule cs WHERE cs.concertId = :concertId AND cs.scheduleDate = :scheduleDate")
+    Optional<ConcertSchedule> findSchedule(Long concertId, LocalDate scheduleDate);
+
+    @Query("SELECT cs.isSoldOut FROM ConcertSchedule cs WHERE cs.concertId = :concertId AND cs.scheduleDate = :scheduleDate")
+    Optional<Boolean> isScheduleSoldOut(@Param("concertId") Long concertId, @Param("scheduleDate") LocalDate scheduleDate);
+
+}

--- a/src/main/java/kr/hhplus/be/server/api/concert/domain/repository/SeatRepository.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/domain/repository/SeatRepository.java
@@ -1,0 +1,25 @@
+package kr.hhplus.be.server.api.concert.domain.repository;
+
+import kr.hhplus.be.server.api.concert.domain.entity.Seat;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SeatRepository extends JpaRepository<Seat, Long> {
+    @Query("SELECT s FROM Seat s WHERE s.concertId = :concertId AND s.scheduleDate = :scheduleDate AND s.status = 'AVAILABLE'")
+    List<Seat> findAvailableSeatList(@Param("concertId") Long concertId, @Param("scheduleDate") LocalDate scheduleDate);
+
+    @Query("SELECT s FROM Seat s WHERE s.concertId = :concertId AND s.scheduleDate = :scheduleDate AND s.seatNumber = :seatNumber")
+    Optional<Seat> findSeat(@Param("concertId") Long concertId,
+                            @Param("scheduleDate") LocalDate scheduleDate,
+                            @Param("seatNumber") int seatNumber);
+
+    @Query("SELECT COUNT(s) FROM Seat s WHERE s.concertId = :concertId AND s.scheduleDate = :scheduleDate AND s.status = 'AVAILABLE'")
+    long countAvailableSeats(@Param("concertId") Long concertId, @Param("scheduleDate") LocalDate scheduleDate);
+}

--- a/src/main/java/kr/hhplus/be/server/api/concert/exception/ConcertErrorCode.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/exception/ConcertErrorCode.java
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.api.concert.exception;
+
+import kr.hhplus.be.server.api.common.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ConcertErrorCode implements ErrorCode {
+    CONCERT_NOT_FOUND(HttpStatus.NOT_FOUND, "CONCERT_NOT_FOUND", "콘서트 정보를 찾을 수 없습니다."),
+    CONCERT_FULL(HttpStatus.CONFLICT, "CONCERT_FULL", "콘서트가 매진되었습니다."),
+    CONCERT_DATE_INVALID(HttpStatus.BAD_REQUEST, "CONCERT_DATE_INVALID", "유효하지 않은 콘서트 날짜입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String name;
+    private final String message;
+
+    ConcertErrorCode(HttpStatus httpStatus, String name, String message) {
+        this.httpStatus = httpStatus;
+        this.name = name;
+        this.message = message;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/concert/exception/SeatErrorCode.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/exception/SeatErrorCode.java
@@ -1,0 +1,24 @@
+package kr.hhplus.be.server.api.concert.exception;
+
+
+import kr.hhplus.be.server.api.common.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum SeatErrorCode implements ErrorCode {
+    SEAT_NOT_FOUND(HttpStatus.NOT_FOUND, "SEAT_NOT_FOUND", "좌석 정보를 찾을 수 없습니다."),
+    SEAT_ALREADY_RESERVED(HttpStatus.CONFLICT, "SEAT_ALREADY_RESERVED", "이미 예약된 좌석입니다."),
+    SEAT_UNAVAILABLE(HttpStatus.BAD_REQUEST, "SEAT_UNAVAILABLE", "선택한 좌석은 사용할 수 없습니다."),
+    SEAT_NOT_RESERVED(HttpStatus.BAD_REQUEST, "SEAT_NOT_RESERVED", "좌석이 예약되지 않았습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String name;
+    private final String message;
+
+    SeatErrorCode(HttpStatus httpStatus, String name, String message) {
+        this.httpStatus = httpStatus;
+        this.name = name;
+        this.message = message;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/concert/presentation/controller/ConcertContoller.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/presentation/controller/ConcertContoller.java
@@ -1,0 +1,55 @@
+package kr.hhplus.be.server.api.concert.presentation.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.hhplus.be.server.api.common.exception.CustomException;
+import kr.hhplus.be.server.api.common.response.ApiResponse;
+import kr.hhplus.be.server.api.concert.application.service.ConcertService;
+import kr.hhplus.be.server.api.concert.presentation.dto.AvailableDateListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/concerts")
+@Tag(name = "Conert", description =  "콘서트 예약 API - 정보 조회")
+public class ConcertContoller {
+
+    private final ConcertService concertService;
+
+    /**
+     * 예매 가능한 날짜 리스트 조회 API
+     * @param concertId
+     * @return 예매 가능한 날짜 리스트
+     */
+    @GetMapping("/{concertId}/dates/available")
+    public ResponseEntity<?> getAvailableDates(@PathVariable Long concertId) {
+        try {
+            List<LocalDate> availableDates = concertService.getAvailableDateList(concertId);
+
+            return ResponseEntity.ok(ApiResponse.success("예약 가능한 날짜 목록을 조회했습니다.", availableDates));
+        } catch (CustomException e) {
+            return ResponseEntity.status(e.getHttpStatus()).body(ApiResponse.error(e.getErrorCode().getName(), e.getMessage()));
+        }
+    }
+
+    /**
+     * 특정 날짜의 예매 가능한 좌석 리스트 조회 API
+     * @param concertId
+     * @param scheduleDate
+     * @return 예매 가능한 좌석 리스트
+     */
+    @GetMapping("/{concertId}/seats/available")
+    public ResponseEntity<?> getAvailableSeats(@PathVariable Long concertId, @RequestParam LocalDate scheduleDate) {
+        try {
+            List<Integer> availableSeats = concertService.getAvailableSeatList(concertId, scheduleDate);
+
+            return ResponseEntity.ok(ApiResponse.success("예약 가능한 좌석 정보를 조회했습니다.", availableSeats));
+        } catch (CustomException e) {
+            return ResponseEntity.status(e.getHttpStatus()).body(ApiResponse.error(e.getErrorCode().getName(), e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/concert/presentation/dto/AvailableDateListResponse.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/presentation/dto/AvailableDateListResponse.java
@@ -1,0 +1,20 @@
+package kr.hhplus.be.server.api.concert.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * 예약 가능한 날짜 목록 응답 DTO
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+public class AvailableDateListResponse {
+
+    private Long concertId;
+    private List<String> availableDateList;
+
+}

--- a/src/main/java/kr/hhplus/be/server/api/concert/presentation/dto/AvailableSeatListResponse.java
+++ b/src/main/java/kr/hhplus/be/server/api/concert/presentation/dto/AvailableSeatListResponse.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.api.concert.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class AvailableSeatListResponse {
+    private List<Integer> availableSeatList;
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/application/ReservationFacade.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/application/ReservationFacade.java
@@ -1,0 +1,84 @@
+package kr.hhplus.be.server.api.reservation.application;
+
+import kr.hhplus.be.server.api.balance.application.service.BalanceService;
+import kr.hhplus.be.server.api.common.exception.CustomException;
+import kr.hhplus.be.server.api.common.type.ReservationStatus;
+import kr.hhplus.be.server.api.concert.application.service.ConcertService;
+import kr.hhplus.be.server.api.reservation.application.dto.PaymentServiceRequest;
+import kr.hhplus.be.server.api.reservation.application.dto.ReservationServiceRequest;
+import kr.hhplus.be.server.api.reservation.application.service.ReservationService;
+import kr.hhplus.be.server.api.reservation.domain.entity.Reservation;
+import kr.hhplus.be.server.api.concert.domain.entity.Seat;
+import kr.hhplus.be.server.api.reservation.exception.ReservationErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationFacade {
+    private final ReservationService reservationService;
+    private final ConcertService concertService;
+    private final BalanceService balanceService;
+
+    /**
+     * 좌석 예약
+     * @param ReservationServiceReq
+     * @return
+     */
+    @Transactional
+    public Reservation reserveSeat(ReservationServiceRequest ReservationServiceReq) {
+        // 좌석 상태 확인 및 예약
+        Seat seat = concertService.reserveSeat(
+                ReservationServiceReq.getConcertId(),
+                ReservationServiceReq.getScheduleDate(),
+                ReservationServiceReq.getSeatNumber()
+        );
+
+        // 예약 생성
+        return reservationService.createReservation(ReservationServiceReq, seat);
+    }
+
+    /**
+     * 예약된 좌석 결제
+     * @param paymentServiceReq
+     * @return
+     */
+    @Transactional
+    public Reservation payReservation(PaymentServiceRequest paymentServiceReq) {
+        // 예약 조회
+        Reservation reservation = reservationService.findById(paymentServiceReq.getReservationId());
+
+        // 예약 상태 확인
+        if (!reservation.getStatus().equals(ReservationStatus.PENDING)) {
+            throw new CustomException(ReservationErrorCode.INVALID_RESERVATION_STATUS);
+        }
+
+        // 잔액 확인
+        Long userBalance = balanceService.getBalance(reservation.getUserId());
+        Long initialPrice = paymentServiceReq.getPrice();
+        Long chargeAmount = initialPrice - userBalance;
+        Long actualAmount = initialPrice;
+
+        if (chargeAmount > 0) {
+            // 부족한 잔액만 충전
+            balanceService.chargeBalance(reservation.getUserId(), chargeAmount);
+            actualAmount = initialPrice - chargeAmount; // 실제 결제 금액 업데이트
+        }
+
+        // 잔액 차감 (실제 결제 금액 사용)
+        balanceService.deductBalance(reservation.getUserId(), actualAmount);
+
+        // 새로운 PaymentServiceRequest 객체 생성 (실제 결제 금액 반영)
+        PaymentServiceRequest updatedPaymentServiceReq = PaymentServiceRequest.builder()
+                .userId(paymentServiceReq.getUserId())
+                .reservationId(paymentServiceReq.getReservationId())
+                .seatId(paymentServiceReq.getSeatId())
+                .price(actualAmount) // 실제 결제 금액
+                .paymentMethod(paymentServiceReq.getPaymentMethod())
+                .build();
+
+        // 예약 상태 업데이트 및 결제 기록 저장
+        return reservationService.payReservation(updatedPaymentServiceReq, ReservationStatus.PAID);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/application/dto/PaymentServiceRequest.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/application/dto/PaymentServiceRequest.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.api.reservation.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PaymentServiceRequest {
+    private Long userId;
+    private Long reservationId;
+    private Long seatId;
+    private Long price;
+    private String paymentMethod;
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/application/dto/ReservationServiceRequest.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/application/dto/ReservationServiceRequest.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.api.reservation.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class ReservationServiceRequest {
+    private Long concertId;
+    private Long userId;
+    private LocalDate scheduleDate;
+    private Long seatId;
+    private int seatNumber;
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/application/service/ReservationService.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/application/service/ReservationService.java
@@ -1,0 +1,83 @@
+package kr.hhplus.be.server.api.reservation.application.service;
+
+import jakarta.transaction.Transactional;
+import kr.hhplus.be.server.api.common.exception.CustomException;
+import kr.hhplus.be.server.api.common.type.ReservationStatus;
+import kr.hhplus.be.server.api.common.type.SeatStatus;
+import kr.hhplus.be.server.api.concert.exception.SeatErrorCode;
+import kr.hhplus.be.server.api.reservation.application.dto.PaymentServiceRequest;
+import kr.hhplus.be.server.api.reservation.application.dto.ReservationServiceRequest;
+import kr.hhplus.be.server.api.reservation.domain.entity.Reservation;
+import kr.hhplus.be.server.api.concert.domain.entity.Seat;
+import kr.hhplus.be.server.api.reservation.domain.entity.repository.ReservationRepository;
+import kr.hhplus.be.server.api.reservation.exception.ReservationErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+
+    public Reservation findById(Long reservationId) {
+        return reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new CustomException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+    }
+
+    /**
+     * 좌석 예약
+     */
+    @Transactional
+    public Reservation createReservation(ReservationServiceRequest serviceRequest, Seat seat) {
+
+        // 중복 예약 확인
+        boolean isDuplicate = reservationRepository.existsByConcertIdAndScheduleDateAndSeatNumber(
+                serviceRequest.getConcertId(),
+                serviceRequest.getScheduleDate(),
+                seat.getSeatNumber()
+        );
+        if (isDuplicate) {
+            throw new CustomException(ReservationErrorCode.RESERVATION_ALREADY_EXISTS);
+        }
+
+        // 예약 생성(validation은 concert에서 좌석 찾을 때 진행)
+        LocalDateTime expiredAt = LocalDateTime.now().plusMinutes(5);
+        Reservation reservation = Reservation.builder()
+                .concertId(serviceRequest.getConcertId())
+                .userId(serviceRequest.getUserId())
+                .scheduleDate(serviceRequest.getScheduleDate())
+                .seatId(serviceRequest.getSeatId())
+                .seatNumber(seat.getSeatNumber())
+                .status(ReservationStatus.PENDING)
+                .price(seat.getPrice())
+                .expiredAt(expiredAt)
+                .build();
+
+        // 예약 저장
+        return reservationRepository.save(reservation);
+    }
+
+    /**
+     * 좌석 결제 및 상태 변경
+     */
+    @Transactional
+    public Reservation payReservation(PaymentServiceRequest paymentServiceReq, ReservationStatus status) {
+        Reservation reservation = findById(paymentServiceReq.getReservationId());
+
+        if (reservation.getStatus() != ReservationStatus.PENDING) {
+            throw new CustomException(ReservationErrorCode.INVALID_RESERVATION_STATUS);
+        }
+
+        Reservation updateReservation = reservation.toBuilder()
+                    .id(paymentServiceReq.getSeatId())
+                    .status(status)
+                    .price(paymentServiceReq.getPrice())
+                    .paidAt(LocalDateTime.now())
+                    .build();
+
+        return reservationRepository.save(updateReservation);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/domain/entity/Reservation.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/domain/entity/Reservation.java
@@ -1,0 +1,39 @@
+package kr.hhplus.be.server.api.reservation.domain.entity;
+
+import jakarta.persistence.*;
+import kr.hhplus.be.server.api.common.type.ReservationStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class Reservation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private Long seatId;
+    private int seatNumber; // 좌석 번호
+
+    private Long concertId; // 콘서트 ID
+    private LocalDate scheduleDate; // 스케줄 날짜
+
+    @Enumerated(EnumType.STRING)
+    private ReservationStatus status; // 예약 상태
+    private LocalDateTime expiredAt; // (좌석)예약 만료일
+
+    private Long price; // (예약좌석)결제 금액
+    private LocalDateTime paidAt; // 결제일
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/domain/entity/repository/ReservationRepository.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/domain/entity/repository/ReservationRepository.java
@@ -1,0 +1,29 @@
+package kr.hhplus.be.server.api.reservation.domain.entity.repository;
+
+import kr.hhplus.be.server.api.reservation.domain.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+    // 특정 콘서트와 날짜에 해당하는 예약 리스트 조회
+    List<Reservation> findByConcertIdAndScheduleDate(Long concertId, LocalDate scheduleDate);
+
+    // 특정 사용자에 대한 모든 예약 조회
+    List<Reservation> findByUserId(Long userId);
+
+    // 특정 좌석에 대한 예약 조회
+    @Query("SELECT r FROM Reservation r WHERE r.concertId = :concertId AND r.scheduleDate = :scheduleDate AND r.seatNumber = :seatNumber")
+    Reservation findReservation(@Param("concertId") Long concertId,
+                                @Param("scheduleDate") LocalDate scheduleDate,
+                                @Param("seatNumber") int seatNumber);
+
+    // 중복 예약 확인
+    boolean existsByConcertIdAndScheduleDateAndSeatNumber(Long concertId, LocalDate scheduleDate, int seatNumber);
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/exception/PaymentErrorCode.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/exception/PaymentErrorCode.java
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.api.reservation.exception;
+
+import kr.hhplus.be.server.api.common.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum PaymentErrorCode implements ErrorCode {
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT_NOT_FOUND", "결제 정보를 찾을 수 없습니다."),
+    PAYMENT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT_FAILED", "결제 처리에 실패했습니다."),
+    PAYMENT_DUPLICATE(HttpStatus.CONFLICT, "PAYMENT_DUPLICATE", "중복 결제가 감지되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String name;
+    private final String message;
+
+    PaymentErrorCode(HttpStatus httpStatus, String name, String message) {
+        this.httpStatus = httpStatus;
+        this.name = name;
+        this.message = message;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/exception/ReservationErrorCode.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/exception/ReservationErrorCode.java
@@ -1,0 +1,24 @@
+package kr.hhplus.be.server.api.reservation.exception;
+
+import kr.hhplus.be.server.api.common.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ReservationErrorCode implements ErrorCode {
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION_NOT_FOUND", "예약 정보를 찾을 수 없습니다."),
+    RESERVATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "RESERVATION_ALREADY_EXISTS", "중복된 예약 정보입니다."),
+    RESERVATION_EXPIRED(HttpStatus.BAD_REQUEST, "RESERVATION_EXPIRED", "예약이 만료되었습니다."),
+    RESERVATION_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "RESERVATION_INVALID_REQUEST", "잘못된 예약 요청입니다."),
+    INVALID_RESERVATION_STATUS(HttpStatus.BAD_REQUEST, "INVALID_RESERVATION_STATUS", "예약 상태가 유효하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String name;
+    private final String message;
+
+    ReservationErrorCode(HttpStatus httpStatus, String name, String message) {
+        this.httpStatus = httpStatus;
+        this.name = name;
+        this.message = message;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/presentation/controller/ReservationController.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/presentation/controller/ReservationController.java
@@ -1,0 +1,73 @@
+package kr.hhplus.be.server.api.reservation.presentation.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.hhplus.be.server.api.common.exception.CustomException;
+import kr.hhplus.be.server.api.common.response.ApiResponse;
+import kr.hhplus.be.server.api.common.response.dto.ResponseDTO;
+import kr.hhplus.be.server.api.reservation.application.ReservationFacade;
+import kr.hhplus.be.server.api.reservation.application.dto.PaymentServiceRequest;
+import kr.hhplus.be.server.api.reservation.application.dto.ReservationServiceRequest;
+import kr.hhplus.be.server.api.reservation.domain.entity.Reservation;
+import kr.hhplus.be.server.api.reservation.presentation.dto.PaymentRequest;
+import kr.hhplus.be.server.api.reservation.presentation.dto.PaymentResponse;
+import kr.hhplus.be.server.api.reservation.presentation.dto.ReservationRequest;
+import kr.hhplus.be.server.api.reservation.presentation.dto.ReservationResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reservations")
+@Tag(name = "Reservation", description =  "콘서트 예약 API - 예약 생성 및 결제")
+public class ReservationController {
+
+    private final ReservationFacade reservationFacade;
+
+    /**
+     * 좌석 예약 요청 API
+     * @param concertId
+     * @param reservationRequest
+     * @return
+     */
+    @PostMapping("/{concertId}/reserve-seats")
+    public ResponseEntity<?> reserveSeat(@PathVariable Long concertId, @RequestBody ReservationRequest reservationRequest) {
+        try {
+            // Presentation DTO -> 서비스 계층 요청 객체 변환
+            ReservationServiceRequest serviceRequest = reservationRequest.toServiceDTO(concertId);
+
+            // 비즈니스 로직 호출
+            Reservation reservation = reservationFacade.reserveSeat(serviceRequest);
+
+            ReservationResponse reservationResponse = ReservationResponse.fromEntity(reservation);
+
+            return ResponseEntity.ok(ApiResponse.success("좌석이 임시로 예약되었습니다.", reservationResponse));
+        } catch (CustomException e) {
+            return ResponseEntity.status(e.getHttpStatus()).body(ApiResponse.error(e.getErrorCode().getName(), e.getMessage()));
+        }
+    }
+
+    /**
+     * 예약한 좌석 결제 API
+     * @param reservationId
+     * @param paymentRequest
+     * @return
+     */
+    @PostMapping("/{reservationId}/payment")
+    public ResponseEntity<?> payment(@PathVariable Long reservationId, @RequestBody PaymentRequest paymentRequest) {
+        try {
+            // Presentation DTO -> 서비스 계층 요청 객체 변환
+            PaymentServiceRequest serviceRequest = paymentRequest.toServiceDTO(reservationId);
+
+            // 비즈니스 로직 호출
+            Reservation updatedReservation = reservationFacade.payReservation(serviceRequest);
+
+            PaymentResponse paymentResponse = PaymentResponse.fromEntity(updatedReservation);
+
+            return ResponseEntity.ok(ApiResponse.success("결제가 성공적으로 처리되었습니다.", paymentResponse));
+        } catch (CustomException e) {
+            return ResponseEntity.status(e.getHttpStatus()).body(ApiResponse.error(e.getErrorCode().getName(), e.getMessage()));
+        }
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/presentation/dto/PaymentInfo.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/presentation/dto/PaymentInfo.java
@@ -1,0 +1,9 @@
+package kr.hhplus.be.server.api.reservation.presentation.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PaymentInfo {
+    private Long price;
+    private String method;
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/presentation/dto/PaymentRequest.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/presentation/dto/PaymentRequest.java
@@ -1,0 +1,24 @@
+package kr.hhplus.be.server.api.reservation.presentation.dto;
+
+import kr.hhplus.be.server.api.reservation.application.dto.PaymentServiceRequest;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PaymentRequest {
+    private Long userId;
+    private PaymentInfo paymentInfo;
+
+    /**
+     * Presentation DTO -> Service DTO 변환
+     */
+    public PaymentServiceRequest toServiceDTO(Long reservationId) {
+        return PaymentServiceRequest.builder()
+                .userId(userId)
+                .reservationId(reservationId)
+                .price(paymentInfo.getPrice())
+                .paymentMethod(paymentInfo.getMethod())
+                .build();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/presentation/dto/PaymentResponse.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/presentation/dto/PaymentResponse.java
@@ -1,0 +1,28 @@
+package kr.hhplus.be.server.api.reservation.presentation.dto;
+
+import kr.hhplus.be.server.api.reservation.domain.entity.Reservation;
+import lombok.*;
+
+import java.time.ZoneId;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentResponse {
+    private Long paymentId;
+    private Long reservationId;
+    private Long price;
+    private Long balance;
+
+    /**
+     * Reservation Entity => PaymentReponse로 변환
+     */
+    public static PaymentResponse fromEntity(Reservation reservation) {
+        return PaymentResponse.builder()
+                .reservationId(reservation.getId())
+                .price(reservation.getPrice())
+                .build();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/presentation/dto/ReservationRequest.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/presentation/dto/ReservationRequest.java
@@ -1,0 +1,32 @@
+package kr.hhplus.be.server.api.reservation.presentation.dto;
+
+import kr.hhplus.be.server.api.reservation.application.dto.ReservationServiceRequest;
+import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReservationRequest {
+    private Long userId;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;    // 예약 할 콘서트 날짜
+    private Long seatId;
+    private Integer seatNo;
+
+    /**
+     * Presentation DTO -> Service DTO 변환
+     */
+    public ReservationServiceRequest toServiceDTO(Long concertId) {
+        return ReservationServiceRequest.builder()
+                .concertId(concertId)
+                .scheduleDate(this.date)
+                .seatId(this.seatId)
+                .seatNumber(this.seatNo)
+                .build();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/presentation/dto/ReservationResponse.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/presentation/dto/ReservationResponse.java
@@ -1,0 +1,36 @@
+package kr.hhplus.be.server.api.reservation.presentation.dto;
+
+import kr.hhplus.be.server.api.reservation.domain.entity.Reservation;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReservationResponse {
+    private Long reservationId;
+    private Long concertId;
+    private LocalDate date;
+    private Long seatId;
+    private int seatNo;
+    private String status;
+    private long reservedUntil; // Unix Timestamp로 변환된 만료 시간
+
+    /**
+     * Reservation Entity => ReservationReponse로 변환
+     */
+    public static ReservationResponse fromEntity(Reservation reservation) {
+        return ReservationResponse.builder()
+                .reservationId(reservation.getId())
+                .concertId(reservation.getConcertId())
+                .date(reservation.getScheduleDate())
+                .seatNo(reservation.getSeatNumber())
+                .status(String.valueOf(reservation.getStatus()))
+                .reservedUntil(reservation.getExpiredAt().atZone(ZoneId.systemDefault()).toEpochSecond())
+                .build();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/token/application/service/TokenService.java
+++ b/src/main/java/kr/hhplus/be/server/api/token/application/service/TokenService.java
@@ -1,0 +1,86 @@
+package kr.hhplus.be.server.api.token.application.service;
+
+import kr.hhplus.be.server.api.common.exception.CustomException;
+import kr.hhplus.be.server.api.common.type.TokenStatus;
+import kr.hhplus.be.server.api.token.domain.entity.Token;
+import kr.hhplus.be.server.api.token.domain.repository.TokenRepository;
+import kr.hhplus.be.server.api.token.domain.validator.TokenValidator;
+import kr.hhplus.be.server.api.token.exception.TokenErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+    private final TokenRepository tokenRepository;
+    private final TokenValidator tokenValidator;
+
+    /**
+     * 토큰 발급 (초기 상태는 PENDING / 대기시간 부여 안함)
+     */
+    public Token issueToken(Long userId) {
+        Token token = Token.builder()
+                .userId(userId)
+                .token(UUID.randomUUID().toString())
+                .status(TokenStatus.PENDING)
+                .createdAt(LocalDateTime.now())
+                .build();
+        return tokenRepository.save(token);
+    }
+
+    /**
+     * 대기열 통과: 상태 변경 및 만료 시간 부여
+     */
+    @Transactional
+    public void processNextInQueue() {
+        Token nextToken = tokenRepository.findFirstByStatusOrderByIdAsc(TokenStatus.PENDING);
+
+        if (nextToken != null) {
+            LocalDateTime now = LocalDateTime.now();
+            nextToken.activate(now.plusMinutes(10), now.plusMinutes(30)); // 만료 시간 설정
+            tokenRepository.save(nextToken); // 기존 객체에 대해 변경 사항 저장
+        }
+    }
+
+    /**
+     * 요청 시 토큰 검증 및 만료 시간 연장
+     */
+    // 1. TokenErrorCode.TOKEN_NOT_FOUND 검증
+    // 2.
+    @Transactional
+    public void validateAndExtendToken(String tokenValue) {
+        Token token = tokenRepository.findByToken(tokenValue)
+                .orElseThrow(() -> new CustomException(TokenErrorCode.TOKEN_NOT_FOUND));
+
+        tokenValidator.validateTokenState(token);
+        tokenValidator.validateTokenExtension(token, 5);
+
+        token.extendExpiration(5); // 만료 시간 5분 연장
+        tokenRepository.save(token);
+    }
+
+    /**
+     * 요청 없는 ACTIVE 토큰 처리
+     * 10분 이상 요청이 없는 ACTIVE 토큰을 EXPIRED로 변경
+     */
+    @Transactional
+    public void expireInactiveActiveTokens() {
+        LocalDateTime now = LocalDateTime.now();
+
+        // ACTIVE 상태의 모든 토큰 조회
+        List<Token> tokens = tokenRepository.findAllByStatus(TokenStatus.ACTIVE);
+
+        for (Token token : tokens) {
+            if (token.getLastRequestAt().plusMinutes(10).isBefore(now)) {
+                token.updateStatus(TokenStatus.EXPIRED); // 상태를 EXPIRED로 변경
+                tokenRepository.save(token); // 상태 저장
+            }
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/token/domain/entity/Token.java
+++ b/src/main/java/kr/hhplus/be/server/api/token/domain/entity/Token.java
@@ -1,0 +1,68 @@
+package kr.hhplus.be.server.api.token.domain.entity;
+
+import jakarta.persistence.*;
+import kr.hhplus.be.server.api.common.exception.CustomException;
+import kr.hhplus.be.server.api.common.type.TokenStatus;
+import kr.hhplus.be.server.api.token.exception.TokenErrorCode;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * Desc :대기열 관리 및 콘서트 좌석 예매 권한을 부여하기 위한 Token
+ */
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class Token {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 대기열 순서로 사용
+    private String token; // token의 value
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    private TokenStatus status;
+
+    private LocalDateTime expiredAt;
+    private LocalDateTime maxExpiredAt; // 절대 만료 시점(연장 불가)
+    private LocalDateTime createdAt;
+    private LocalDateTime lastRequestAt; // 마지막 요청 시간 기록
+
+    // 토큰 만료 여부 체크 (ACTIVE 상태에서만 적용)
+    public boolean isExpired() {
+        return expiredAt != null && LocalDateTime.now().isAfter(expiredAt);
+    }
+
+    public boolean isMaxExpired() {
+        return maxExpiredAt != null && LocalDateTime.now().isAfter(maxExpiredAt);
+    }
+
+    // 활성화 상태로 변경
+    public void activate(LocalDateTime expiration, LocalDateTime maxExpiration) {
+        this.status = TokenStatus.ACTIVE;
+        this.expiredAt = expiration;
+        this.maxExpiredAt = maxExpiration;
+    }
+
+    // 상태 업데이트
+    public void updateStatus(TokenStatus status) {
+        this.status = status;
+    }
+
+    // 만료 시간 추가로 연장
+    public void extendExpiration(int addMin) {
+
+        LocalDateTime newExpiryTime = expiredAt.plusMinutes(addMin);
+
+        // 절대 만료 시점(MaxExpiredAt)을 초과하지 않도록 제한
+        if (newExpiryTime.isBefore(maxExpiredAt)) {
+            this.expiredAt = newExpiryTime;
+        } else {
+            this.expiredAt = maxExpiredAt; // 초과 시 절대 만료 시점으로 설정
+        }
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/api/token/domain/repository/TokenRepository.java
+++ b/src/main/java/kr/hhplus/be/server/api/token/domain/repository/TokenRepository.java
@@ -1,0 +1,32 @@
+package kr.hhplus.be.server.api.token.domain.repository;
+
+import kr.hhplus.be.server.api.common.type.TokenStatus;
+import kr.hhplus.be.server.api.token.domain.entity.Token;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TokenRepository extends JpaRepository<Token, Long> {
+
+    List<Token> findByStatusAndCreatedAtBefore(TokenStatus status, LocalDateTime time);
+
+    @Query("SELECT t FROM Token t WHERE t.status = :status AND t.lastRequestAt < :time")
+    List<Token> findByStatusAndLastRequestAtBefore(
+            @Param("status") TokenStatus status,
+            @Param("time") LocalDateTime time
+    );
+
+    Token findFirstByStatusOrderByIdAsc(TokenStatus status);
+
+    Optional<Token> findByToken(String tokenValue);
+
+    List<Token> findAllByStatus(TokenStatus tokenStatus);
+}

--- a/src/main/java/kr/hhplus/be/server/api/token/domain/validator/TokenValidator.java
+++ b/src/main/java/kr/hhplus/be/server/api/token/domain/validator/TokenValidator.java
@@ -1,0 +1,44 @@
+package kr.hhplus.be.server.api.token.domain.validator;
+
+import kr.hhplus.be.server.api.common.exception.CustomException;
+import kr.hhplus.be.server.api.common.type.TokenStatus;
+import kr.hhplus.be.server.api.token.domain.entity.Token;
+import kr.hhplus.be.server.api.token.exception.TokenErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cglib.core.Local;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class TokenValidator {
+
+    public void validateTokenState(Token token) {
+        if (token == null) {
+            throw new CustomException(TokenErrorCode.TOKEN_NOT_FOUND);
+        }
+
+        // 토큰 상태가 ACTIVE가 아닌 경우
+        if (token.getStatus() != TokenStatus.ACTIVE) {
+            throw new CustomException(TokenErrorCode.TOKEN_NOT_ACTIVE);
+        }
+
+        // expiredAt이 null인 경우(대기열을 통과하지 못한 것으로 간주)
+        if (token.getExpiredAt() == null) {
+            throw new CustomException(TokenErrorCode.TOKEN_NOT_PASSED_QUEUE);
+        }
+
+        // expiredAt이 만료된 경우
+        if (token.isExpired()) {
+            throw new CustomException(TokenErrorCode.TOKEN_EXPIRED);
+        }
+    }
+
+    public void validateTokenExtension(Token token, int addMinutes) {
+        if (token.getExpiredAt() != null && token.getExpiredAt().plusMinutes(addMinutes).isAfter(token.getMaxExpiredAt())) {
+            throw new CustomException(TokenErrorCode.TOKEN_MAX_EXTENSION_EXCEEDED);
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/token/exception/TokenErrorCode.java
+++ b/src/main/java/kr/hhplus/be/server/api/token/exception/TokenErrorCode.java
@@ -1,0 +1,27 @@
+package kr.hhplus.be.server.api.token.exception;
+
+import kr.hhplus.be.server.api.common.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum TokenErrorCode implements ErrorCode {
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "TOKEN_NOT_FOUND", "토큰 정보를 찾을 수 없습니다."),
+    TOKEN_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "TOKEN_INVALID_REQUEST", "요청 데이터가 유효하지 않습니다."),
+    TOKEN_INVALID_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "TOKEN_INVALID_RESPONSE", "토큰 응답이 유효하지 않습니다."),
+    TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "TOKEN_EXPIRED", "토큰이 만료되었습니다."),
+    TOKEN_MAX_EXTENSION_EXCEEDED(HttpStatus.BAD_REQUEST, "TOKEN_MAX_EXTENSION_EXCEEDED", "최대 연장 시간을 초과할 수 없습니다."),
+    TOKEN_NOT_PASSED_QUEUE(HttpStatus.BAD_REQUEST, "TOKEN_NOT_IN_QUEUE", "토큰이 대기열을 통과하지 못했습니다."),
+    TOKEN_NOT_ACTIVE(HttpStatus.FORBIDDEN, "TOKEN_NOT_ACTIVE", "토큰이 활성 상태가 아닙니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String name;
+    private final String message;
+
+    TokenErrorCode(HttpStatus httpStatus, String name, String message) {
+        this.httpStatus = httpStatus;
+        this.name = name;
+        this.message = message;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/token/infrastructure/TokenInterceptor.java
+++ b/src/main/java/kr/hhplus/be/server/api/token/infrastructure/TokenInterceptor.java
@@ -1,0 +1,39 @@
+package kr.hhplus.be.server.api.token.infrastructure;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.hhplus.be.server.api.token.application.service.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class TokenInterceptor implements HandlerInterceptor {
+
+    private final TokenService tokenService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String tokenValue = request.getHeader("Authorization");
+
+
+        if (tokenValue == null || tokenValue.isEmpty()) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("토큰이 누락되었거나 잘못되었습니다.");
+            return false;
+        }
+
+        try {
+            // TokenService를 통해 검증 및 만료 시간 (5분) 연장
+            tokenService.validateAndExtendToken(tokenValue);
+        } catch (Exception e) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write(e.getMessage());
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/api/token/presentation/controller/TokenController.java
+++ b/src/main/java/kr/hhplus/be/server/api/token/presentation/controller/TokenController.java
@@ -1,0 +1,66 @@
+package kr.hhplus.be.server.api.token.presentation.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.hhplus.be.server.api.common.exception.CustomException;
+import kr.hhplus.be.server.api.common.response.ApiResponse;
+import kr.hhplus.be.server.api.token.application.service.TokenService;
+import kr.hhplus.be.server.api.token.domain.entity.Token;
+import kr.hhplus.be.server.api.token.exception.TokenErrorCode;
+import kr.hhplus.be.server.api.token.presentation.dto.TokenRequest;
+import kr.hhplus.be.server.api.token.presentation.dto.TokenIssueResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+@Tag(name = "Token", description =  "토큰 API")
+public class TokenController {
+
+    private final TokenService tokenService;
+
+    @PostMapping("/tokens")
+    public ResponseEntity<?> issueToken(@Valid @RequestBody TokenRequest request) {
+        try {
+            if (request.getUserId() == null) {
+                throw new CustomException(TokenErrorCode.TOKEN_INVALID_REQUEST);
+            }
+
+            // 토큰 발급
+            Token token = tokenService.issueToken(request.getUserId());
+            if (token == null || token.getId() == null || token.getToken() == null) {
+                throw new CustomException(TokenErrorCode.TOKEN_INVALID_RESPONSE);
+            }
+
+            // 토큰 response 생성
+            TokenIssueResponse tokenIssueResponse = TokenIssueResponse.fromEntity(token, token.getId(), false);
+
+            // 응답 헤더 설정
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", token.getToken());
+
+            // ApiResponse와 헤더를 함께 반환
+            return ResponseEntity.ok()
+                    .headers(headers)
+                    .body(ApiResponse.success(
+                            "토큰 발급 및 대기열 등록이 완료되었습니다.",
+                            tokenIssueResponse
+                    ));
+        } catch (CustomException e) {
+            return ResponseEntity.status(e.getHttpStatus()).body(
+                    ApiResponse.error(e.getErrorCode().getName(), e.getMessage())
+            );
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    ApiResponse.error("INTERNAL_SERVER_ERROR", "알 수 없는 오류가 발생했습니다.")
+            );
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/token/presentation/dto/TokenIssueResponse.java
+++ b/src/main/java/kr/hhplus/be/server/api/token/presentation/dto/TokenIssueResponse.java
@@ -1,0 +1,25 @@
+package kr.hhplus.be.server.api.token.presentation.dto;
+
+import kr.hhplus.be.server.api.token.domain.entity.Token;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenIssueResponse {
+    private Long queueSort; // 대기열 순서
+    private LocalDateTime expiredAt; // 만료 시간 (Epoch Second)
+    private boolean hasPassedQueue; // 대기열 통과 여부
+
+    public static TokenIssueResponse fromEntity(Token token, Long queueSort, boolean hasPassedQueue) {
+        return new TokenIssueResponse(
+                queueSort,
+                token.getExpiredAt(),
+                hasPassedQueue
+        );
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/token/presentation/dto/TokenRequest.java
+++ b/src/main/java/kr/hhplus/be/server/api/token/presentation/dto/TokenRequest.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.api.token.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenRequest {
+    private Long userId;
+}

--- a/src/main/java/kr/hhplus/be/server/api/token/scheduler/QueueScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/api/token/scheduler/QueueScheduler.java
@@ -1,0 +1,38 @@
+package kr.hhplus.be.server.api.token.scheduler;
+
+import kr.hhplus.be.server.api.common.type.TokenStatus;
+import kr.hhplus.be.server.api.token.application.service.TokenService;
+import kr.hhplus.be.server.api.token.domain.entity.Token;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+@Component
+@RequiredArgsConstructor
+public class QueueScheduler {
+    private final TokenService tokenService;
+
+    /**
+     * 대기열에서 PENDING -> ACTIVE 상태 전환
+     */
+    @Scheduled(fixedRate = 5000) // 5초마다 실행
+    public void processQueue() {
+        tokenService.processNextInQueue();
+    }
+
+    /**
+     * 10분 이상 요청 없는 ACTIVE 토큰을 EXPIRED로 처리
+     */
+//    @Scheduled(cron = "0 */10 * * * ?") // 매 10분마다 실행
+    @Scheduled(fixedRate = 5000)
+    public void expireInactiveActiveTokens() {
+        tokenService.expireInactiveActiveTokens();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/config/jpa/JpaConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/jpa/JpaConfig.java
@@ -9,7 +9,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
 @EnableJpaAuditing
-@EnableJpaRepositories
+@EnableJpaRepositories(basePackages = "kr.hhplus.be")
 public class JpaConfig {
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,9 +14,10 @@ spring:
   jpa:
     open-in-view: false
     generate-ddl: false
-    show-sql: false
+    show-sql: true
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
+#      ddl-auto: create
     properties:
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC
@@ -29,3 +30,27 @@ spring:
     url: jdbc:mysql://localhost:3307/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
     username: application
     password: application
+  sql:
+    init:
+      mode: always
+
+logging:
+  level:
+    org.springframework.jdbc.datasource.init.ScriptUtils: DEBUG
+
+# Swagger
+springdoc:
+  # Swagger UI 접속 경로 설정 (http://localhost:8080/swagger-ui/index.html)
+  swagger-ui:
+    path: /swagger-ui.html
+    operations-sorter: alpha # UI에서 API 메서드(operations) 정렬 방식을 알파벳 순으로 설정
+    tags-sorter: alpha # UI에서 태그(tags) 정렬 방식을 알파벳 순으로 설정
+    disable-swagger-default-url: true  # 기본 Swagger URL 비활성화 (JSON 문서 대신 UI에서 파라미터 사용)
+    doc-expansion: none # Swagger UI에서 기본적으로 문서를 접지 않은 상태로 표시
+  # OpenAPI JSON 문서 확인 경로 설정 (http://localhost:8080/api-docs)
+  api-docs:
+    path: /api-docs
+  # 기본 요청/응답 콘텐츠 타입을 JSON으로 설정
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,50 @@
+-- 테이블 데이터 초기화
+DELETE FROM user;
+DELETE FROM token;
+DELETE FROM concert;
+DELETE FROM concert_schedule;
+DELETE FROM seat;
+DELETE FROM reservation;
+
+-- user 테이블 초기 데이터
+INSERT INTO user (id) VALUES
+(1),
+(2),
+(3);
+
+-- token 테이블 초기 데이터
+INSERT INTO token (id, token, user_id, status, expired_at, max_expired_at, created_at) VALUES
+(1, 'token-1', 1, 'ACTIVE', '2025-01-15 23:59:59', '2025-01-20 23:59:59', '2025-01-01 10:00:00'),
+(2, 'token-2', 2, 'EXPIRED', '2025-01-10 23:59:59', '2025-01-15 23:59:59', '2025-01-02 11:00:00'),
+(3, 'token-3', 3, 'ACTIVE', '2025-01-25 23:59:59', '2025-01-30 23:59:59', '2025-01-03 12:00:00');
+
+-- concert 테이블 초기 데이터
+INSERT INTO concert (id) VALUES
+(1),
+(2);
+
+-- Field 'is_sold_out' doesn't have a default value
+-- concert_schedule 테이블 초기 데이터
+INSERT INTO concert_schedule (id, concert_id, schedule_date, is_sold_out) VALUES
+(1, 1, '2025-01-15', false),
+(2, 1, '2025-01-16', false),
+(3, 2, '2025-01-17', true);
+
+-- seat 테이블 초기 데이터
+INSERT INTO seat (id, seat_number, concert_id, schedule_date, status, price) VALUES
+-- 2025-01-15 공연 좌석
+(1, 1, 1, '2025-01-15', 'AVAILABLE', 50000),
+(2, 2, 1, '2025-01-15', 'AVAILABLE', 70000),
+(3, 3, 1, '2025-01-15', 'RESERVED', 35000),
+-- 2025-01-16 공연 좌석
+(4, 1, 1, '2025-01-16', 'AVAILABLE', 62000),
+(5, 2, 1, '2025-01-16', 'RESERVED', 150000),
+-- 2025-01-17 공연 좌석
+(6, 1, 2, '2025-01-17', 'RESERVED', 200000),
+(7, 2, 2, '2025-01-17', 'RESERVED', 180000);
+
+-- reservation 테이블 초기 데이터
+INSERT INTO reservation (id, user_id, seat_id, seat_number, concert_id, schedule_date, status, expired_at, price, paid_at) VALUES
+(1, 1, 3, 3, 1, '2025-01-15', 'PENDING', '2025-01-20 23:59:59', 50000, NULL),
+(2, 2, 5, 2, 1, '2025-01-16', 'PAID', '2025-01-20 23:59:59', 75000, '2025-01-10 12:00:00'),
+(3, 3, 6, 1, 2, '2025-01-17', 'PENDING', '2025-01-25 23:59:59', 100000, NULL);

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
@@ -1,9 +1,6 @@
 package kr.hhplus.be.server;
 
 import jakarta.annotation.PreDestroy;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;

--- a/src/test/java/kr/hhplus/be/server/api/TestcontainersConfig.java
+++ b/src/test/java/kr/hhplus/be/server/api/TestcontainersConfig.java
@@ -1,0 +1,37 @@
+package kr.hhplus.be.server.api;
+
+import jakarta.annotation.PreDestroy;
+import org.testcontainers.containers.MySQLContainer;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TestcontainersConfig {
+
+    public static final MySQLContainer<?> MYSQL_CONTAINER;
+
+    static {
+        // MySQL Testcontainer 초기화
+        MYSQL_CONTAINER = new MySQLContainer<>("mysql:8.0")
+                .withDatabaseName("testdb")
+                .withUsername("test")
+                .withPassword("test");
+//              .withInitScript("schema.sql")
+
+        // 컨테이너 시작
+        MYSQL_CONTAINER.start();
+
+        // Spring Datasource 설정
+        System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
+        System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
+        System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
+    }
+
+    // @PreDestroy를 이용한 종료 처리
+    @PreDestroy
+    public void preDestroy() {
+        if (MYSQL_CONTAINER.isRunning()) {
+            MYSQL_CONTAINER.stop();
+        }
+    }
+}
+

--- a/src/test/java/kr/hhplus/be/server/api/balance/BalanceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/balance/BalanceIntegrationTest.java
@@ -1,0 +1,40 @@
+package kr.hhplus.be.server.api.balance;
+
+import kr.hhplus.be.server.api.balance.application.service.BalanceService;
+import kr.hhplus.be.server.api.balance.domain.entity.Balance;
+import kr.hhplus.be.server.api.balance.infrastructure.BalanceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+class BalanceIntegrationTest {
+
+    @Autowired
+    private BalanceService balanceService;
+
+    @Autowired
+    private BalanceRepository balanceRepository;
+
+    @BeforeEach
+    void setUp() {
+        balanceRepository.deleteAll();
+        balanceRepository.save(Balance.builder().userId(1L).balance(5000L).build());
+    }
+
+    @Test
+    void 잔액_충전_성공() {
+        // When
+        balanceService.chargeBalance(1L, 10000L);
+
+        // Then
+        Balance updatedBalance = balanceRepository.findByUserId(1L).orElse(null);
+        assertNotNull(updatedBalance);
+        assertEquals(15000L, updatedBalance.getBalance());
+    }
+}
+

--- a/src/test/java/kr/hhplus/be/server/api/balance/BalanceServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/balance/BalanceServiceTest.java
@@ -1,0 +1,42 @@
+package kr.hhplus.be.server.api.balance;
+
+import kr.hhplus.be.server.api.balance.application.service.BalanceService;
+import kr.hhplus.be.server.api.balance.domain.entity.Balance;
+import kr.hhplus.be.server.api.balance.infrastructure.BalanceRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class BalanceServiceTest {
+
+    @Mock
+    private BalanceRepository balanceRepository;
+
+    @InjectMocks
+    private BalanceService balanceService;
+
+    @Test
+    void 잔액_충전_성공() {
+        // Given
+        Long userId = 1L;
+        Balance balance = Balance.builder().userId(userId).balance(5000L).build();
+        when(balanceRepository.findByUserId(userId)).thenReturn(Optional.of(balance));
+
+        // When
+        balanceService.chargeBalance(userId, 10000L);
+
+        // Then
+        assertEquals(15000L, balance.getBalance());
+        verify(balanceRepository, times(1)).save(balance);
+    }
+}
+
+

--- a/src/test/java/kr/hhplus/be/server/api/concert/ConcertIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/concert/ConcertIntegrationTest.java
@@ -1,0 +1,78 @@
+package kr.hhplus.be.server.api.concert;
+
+import kr.hhplus.be.server.api.common.type.SeatStatus;
+import kr.hhplus.be.server.api.concert.application.service.ConcertService;
+import kr.hhplus.be.server.api.concert.domain.entity.ConcertSchedule;
+import kr.hhplus.be.server.api.concert.domain.entity.Seat;
+import kr.hhplus.be.server.api.concert.domain.repository.ConcertScheduleRepository;
+import kr.hhplus.be.server.api.concert.domain.repository.SeatRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class ConcertIntegrationTest {
+
+    @Autowired
+    private ConcertService concertService;
+
+    @Autowired
+    private SeatRepository seatRepository;
+
+    @Autowired
+    private ConcertScheduleRepository concertScheduleRepository;
+
+    @BeforeEach
+    void setUp() {
+        concertScheduleRepository.deleteAll();
+        seatRepository.deleteAll();
+
+        concertScheduleRepository.saveAll(List.of(
+                ConcertSchedule.builder()
+                        .concertId(1L)
+                        .scheduleDate(LocalDate.of(2025, 1, 10))
+                        .isSoldOut(false)
+                        .build(),
+                ConcertSchedule.builder()
+                        .concertId(1L)
+                        .scheduleDate(LocalDate.of(2025, 1, 11))
+                        .isSoldOut(false)
+                        .build()
+        ));
+        seatRepository.saveAll(List.of(
+                Seat.builder().concertId(1L).scheduleDate(LocalDate.of(2025, 1, 10)).seatNumber(1).status(SeatStatus.AVAILABLE).build(),
+                Seat.builder().concertId(1L).scheduleDate(LocalDate.of(2025, 1, 10)).seatNumber(2).status(SeatStatus.AVAILABLE).build(),
+                Seat.builder().concertId(1L).scheduleDate(LocalDate.of(2025, 1, 10)).seatNumber(3).status(SeatStatus.AVAILABLE).build(),
+                Seat.builder().concertId(1L).scheduleDate(LocalDate.of(2025, 1, 10)).seatNumber(4).status(SeatStatus.RESERVED).build()
+        ));
+    }
+
+    @Test
+    void 예약_가능한_날짜_조회_성공() {
+        // When
+        List<LocalDate> result = concertService.getAvailableDateList(1L);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void 예약_가능한_좌석_목록_조회_성공() {
+        // When
+        List<Integer> result = concertService.getAvailableSeatList(1L, LocalDate.of(2025, 1, 10));
+
+        // Then
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertTrue(result.contains(1));
+    }
+}
+
+

--- a/src/test/java/kr/hhplus/be/server/api/concert/ConcertServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/concert/ConcertServiceTest.java
@@ -1,0 +1,84 @@
+package kr.hhplus.be.server.api.concert;
+
+import kr.hhplus.be.server.api.common.type.SeatStatus;
+import kr.hhplus.be.server.api.concert.application.service.ConcertService;
+import kr.hhplus.be.server.api.concert.domain.entity.ConcertSchedule;
+import kr.hhplus.be.server.api.concert.domain.entity.Seat;
+import kr.hhplus.be.server.api.concert.domain.repository.ConcertScheduleRepository;
+import kr.hhplus.be.server.api.concert.domain.repository.SeatRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConcertServiceTest {
+
+    @Mock
+    ConcertScheduleRepository concertScheduleRepository;
+
+    @Mock
+    SeatRepository seatRepository;
+
+    @InjectMocks
+    private ConcertService concertService;
+
+    @Test
+    void 예약_가능한_날짜_조회_성공() {
+        // Given
+        Long concertId = 1L;
+        List<ConcertSchedule> schedules = List.of(
+                ConcertSchedule.builder()
+                        .concertId(concertId)
+                        .scheduleDate(LocalDate.of(2025, 1, 10))
+                        .isSoldOut(false)
+                        .build(),
+                ConcertSchedule.builder()
+                        .concertId(concertId)
+                        .scheduleDate(LocalDate.of(2025, 1, 11))
+                        .isSoldOut(false)
+                        .build()
+        );
+        when(concertScheduleRepository.findByConcertIdAndIsSoldOut(concertId, false)).thenReturn(schedules);
+
+        // When
+        List<LocalDate> result = concertService.getAvailableDateList(concertId);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertTrue(result.contains(LocalDate.of(2025, 1, 10)));
+    }
+
+    @Test
+    void 예약_가능한_좌석_목록_조회_성공() {
+        // Given
+        Long concertId = 1L;
+        LocalDate scheduleDate = LocalDate.of(2025, 1, 10);
+        List<Seat> availableSeats = List.of(
+                Seat.builder().seatNumber(1).status(SeatStatus.AVAILABLE).build(),
+                Seat.builder().seatNumber(2).status(SeatStatus.AVAILABLE).build(),
+                Seat.builder().seatNumber(3).status(SeatStatus.AVAILABLE).build()
+        );
+        when(seatRepository.findAvailableSeatList(concertId, scheduleDate)).thenReturn(availableSeats);
+
+        // When
+        List<Integer> result = concertService.getAvailableSeatList(concertId, scheduleDate);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(3, result.size());
+        assertTrue(result.contains(1));
+        assertTrue(result.contains(2));
+    }
+}
+

--- a/src/test/java/kr/hhplus/be/server/api/reservation/ReservationIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/reservation/ReservationIntegrationTest.java
@@ -1,0 +1,144 @@
+package kr.hhplus.be.server.api.reservation;
+
+import kr.hhplus.be.server.api.common.exception.CustomException;
+import kr.hhplus.be.server.api.common.type.ReservationStatus;
+import kr.hhplus.be.server.api.common.type.SeatStatus;
+import kr.hhplus.be.server.api.concert.domain.entity.ConcertSchedule;
+import kr.hhplus.be.server.api.concert.domain.entity.Seat;
+import kr.hhplus.be.server.api.concert.domain.repository.ConcertScheduleRepository;
+import kr.hhplus.be.server.api.concert.domain.repository.SeatRepository;
+import kr.hhplus.be.server.api.reservation.application.ReservationFacade;
+import kr.hhplus.be.server.api.reservation.application.dto.PaymentServiceRequest;
+import kr.hhplus.be.server.api.reservation.application.dto.ReservationServiceRequest;
+import kr.hhplus.be.server.api.reservation.domain.entity.Reservation;
+import kr.hhplus.be.server.api.reservation.domain.entity.repository.ReservationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+public class ReservationIntegrationTest {
+
+    @Autowired
+    private ReservationFacade reservationFacade;
+
+    @Autowired
+    private SeatRepository seatRepository;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private ConcertScheduleRepository concertScheduleRepository;
+
+    @BeforeEach
+    void setUp() {
+        // 데이터 초기화
+        seatRepository.deleteAll();
+        concertScheduleRepository.deleteAll();
+        reservationRepository.deleteAll();
+
+        concertScheduleRepository.save(ConcertSchedule.builder()
+                .concertId(1L)
+                .scheduleDate(LocalDate.of(2025, 1, 10))
+                .isSoldOut(false)
+                .build());
+
+        seatRepository.saveAll(List.of(
+                Seat.builder().concertId(1L).scheduleDate(LocalDate.of(2025, 1, 10)).seatNumber(1).status(SeatStatus.AVAILABLE).build(),
+                Seat.builder().concertId(1L).scheduleDate(LocalDate.of(2025, 1, 10)).seatNumber(2).status(SeatStatus.AVAILABLE).build(),
+                Seat.builder().concertId(1L).scheduleDate(LocalDate.of(2025, 1, 10)).seatNumber(20).status(SeatStatus.AVAILABLE).build()
+        ));
+
+        List<Seat> seats = seatRepository.findAll();
+        System.out.println("Seats: " + seats);
+    }
+
+    @Test
+    void 좌석_예약_성공() {
+        // Given
+        ReservationServiceRequest reservationRequest = ReservationServiceRequest.builder()
+                .concertId(1L)
+                .userId(999L)
+                .seatId(1L)
+                .scheduleDate(LocalDate.of(2025, 1, 10))
+                .seatNumber(1)
+                .build();
+
+        // When
+        Reservation reservation = reservationFacade.reserveSeat(reservationRequest);
+
+        // Then
+        assertNotNull(reservation);
+        assertEquals(1L, reservation.getConcertId());
+        assertEquals(LocalDate.of(2025, 1, 10), reservation.getScheduleDate());
+        assertEquals(1, reservation.getSeatNumber());
+        assertEquals(ReservationStatus.PENDING, reservation.getStatus());
+
+        // 좌석 상태 확인
+        Seat updatedSeat = seatRepository.findById(reservation.getSeatId()).orElse(null);
+        assertNotNull(updatedSeat);
+        assertEquals(SeatStatus.RESERVED, updatedSeat.getStatus());
+    }
+
+    @Test
+    void 좌석_예약_중복_실패() {
+        // Given : 좌석 예약 요청 생성
+        ReservationServiceRequest reservationRequest = ReservationServiceRequest.builder()
+                .concertId(1L)
+                .userId(999L)
+                .scheduleDate(LocalDate.of(2025, 1, 10))
+                .seatNumber(1)
+                .build();
+
+        // Given : 좌석 예약
+        reservationFacade.reserveSeat(reservationRequest);
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            reservationFacade.reserveSeat(reservationRequest);
+        });
+        assertEquals("이미 예약된 좌석입니다.", exception.getMessage());
+    }
+
+    @Test
+    void 예약된_좌석_결제_성공() {
+        // Given: 좌석 예약 요청 생성
+        ReservationServiceRequest reservationRequest = ReservationServiceRequest.builder()
+                .concertId(1L)
+                .userId(999L)
+                .seatId(1L)
+                .scheduleDate(LocalDate.of(2025, 1, 10))
+                .seatNumber(1)
+                .build();
+
+        Reservation reservation = reservationFacade.reserveSeat(reservationRequest);
+
+        PaymentServiceRequest paymentRequest = PaymentServiceRequest.builder()
+                .reservationId(reservation.getId())
+                .userId(1L)
+                .seatId(1L)
+                .price(10000L)
+                .build();
+
+        // When: 좌석 결제 요청
+        Reservation paidReservation = reservationFacade.payReservation(paymentRequest);
+
+        // Then: 결제 상태 확인
+        assertNotNull(paidReservation);
+        assertEquals(ReservationStatus.PAID, paidReservation.getStatus());
+        assertEquals(10000L, paidReservation.getPrice());
+
+        // 결제된 좌석 상태 확인
+        Seat paidSeat = seatRepository.findById(paidReservation.getSeatId()).orElse(null);
+        assertNotNull(paidSeat);
+        assertEquals(SeatStatus.RESERVED, paidSeat.getStatus());
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/api/reservation/ReservationServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/reservation/ReservationServiceTest.java
@@ -1,0 +1,72 @@
+package kr.hhplus.be.server.api.reservation;
+
+import kr.hhplus.be.server.api.common.type.ReservationStatus;
+import kr.hhplus.be.server.api.common.type.SeatStatus;
+import kr.hhplus.be.server.api.concert.domain.entity.Seat;
+import kr.hhplus.be.server.api.reservation.application.dto.PaymentServiceRequest;
+import kr.hhplus.be.server.api.reservation.application.dto.ReservationServiceRequest;
+import kr.hhplus.be.server.api.reservation.application.service.ReservationService;
+import kr.hhplus.be.server.api.reservation.domain.entity.Reservation;
+import kr.hhplus.be.server.api.reservation.domain.entity.repository.ReservationRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+// Reservation 관련 테스트 클래스
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceTest {
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @InjectMocks
+    private ReservationService reservationService;
+
+    @Test
+    void 좌석예약_생성_테스트() {
+        // given: 예약 요청과 좌석 정보
+        ReservationServiceRequest serviceRequest = ReservationServiceRequest.builder().build();
+        Seat seat = Seat.builder().seatNumber(1).status(SeatStatus.AVAILABLE).build();
+        Reservation reservation = Reservation.builder()
+                .id(1L)
+                .seatId(seat.getId())
+                .status(ReservationStatus.PENDING)
+                .build();
+
+        when(reservationRepository.save(any(Reservation.class))).thenReturn(reservation);
+
+        // when: 예약 생성
+        var result = reservationService.createReservation(serviceRequest, seat);
+
+        // then: 예약 확인
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    void 결제후_예약상태_변경_테스트() {
+        // given: 결제 요청과 상태
+        PaymentServiceRequest paymentRequest = PaymentServiceRequest.builder().build();
+        Reservation reservation = Reservation.builder()
+                .id(1L)
+                .seatId(Seat.builder().seatNumber(1).status(SeatStatus.RESERVED).build().getId())
+                .status(ReservationStatus.PENDING)
+                .build();
+
+        when(reservationRepository.findById(1L)).thenReturn(java.util.Optional.of(reservation));
+        when(reservationRepository.save(any(Reservation.class))).thenReturn(reservation);
+
+        // when: 예약 결제
+        var updatedReservation = reservationService.payReservation(paymentRequest, ReservationStatus.PAID);
+
+        // then: 상태 확인
+        assertThat(updatedReservation.getStatus()).isEqualTo(ReservationStatus.PAID);
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/api/token/TokenIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/token/TokenIntegrationTest.java
@@ -1,0 +1,136 @@
+package kr.hhplus.be.server.api.token;
+
+import kr.hhplus.be.server.api.common.exception.CustomException;
+import kr.hhplus.be.server.api.common.type.TokenStatus;
+import kr.hhplus.be.server.api.token.application.service.TokenService;
+import kr.hhplus.be.server.api.token.domain.entity.Token;
+import kr.hhplus.be.server.api.token.domain.repository.TokenRepository;
+import kr.hhplus.be.server.api.token.exception.TokenErrorCode;
+import kr.hhplus.be.server.api.token.scheduler.QueueScheduler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@EnableScheduling
+@ActiveProfiles("test")
+public class TokenIntegrationTest {
+
+    @Autowired
+    private TokenService tokenService;
+
+    @Autowired
+    private TokenRepository tokenRepository;
+
+    @Autowired
+    private QueueScheduler queueScheduler;
+
+    @BeforeEach
+    void setUp() {
+        tokenRepository.deleteAll();
+    }
+
+    @Test
+    void 대기열_토큰_발급_성공() {
+        // Given
+        Long userId = 1L;
+
+        // When
+        Token token = tokenService.issueToken(userId);
+
+        // Then
+        assertThat(token).isNotNull();
+        assertThat(token.getUserId()).isEqualTo(userId);
+    }
+
+    @Test
+    void 유효한_토큰으로_검증_및_만료시간_연장_성공() {
+        // Given
+        String tokenValue = "valid-token";
+        Token token = Token.builder()
+                .id(1L)
+                .token(tokenValue)
+                .status(TokenStatus.ACTIVE)
+                .expiredAt(LocalDateTime.now().plusMinutes(5))  // 초기 만료 시간
+                .maxExpiredAt(LocalDateTime.now().plusMinutes(30))  // 최대 만료 시간
+                .build();
+        tokenRepository.save(token);
+
+        // When
+        tokenService.validateAndExtendToken(tokenValue);
+
+        // Then
+        Token updatedToken = tokenRepository.findByToken(tokenValue).orElse(null);
+        assertThat(updatedToken).isNotNull();
+        assertThat(updatedToken.getExpiredAt()).isAfter(LocalDateTime.now());
+        assertThat(updatedToken.getExpiredAt()).isBefore(updatedToken.getMaxExpiredAt());
+    }
+
+    @Test
+    void 만료된_토큰_검증_실패() {
+        // Given
+        String tokenValue = "expired-token";
+        Token token = Token.builder()
+                .id(1L)
+                .token(tokenValue)
+                .status(TokenStatus.ACTIVE)
+                .expiredAt(LocalDateTime.now().minusMinutes(1))  // 이미 만료된 상태
+                .build();
+        tokenRepository.save(token);
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> tokenService.validateAndExtendToken(tokenValue));
+        assertThat(exception.getErrorCode()).isEqualTo(TokenErrorCode.TOKEN_EXPIRED);
+    }
+
+    @Test
+    void 스케줄러_대기열_토큰_처리_성공() throws InterruptedException {
+        // Given
+        String tokenValue = "pending-token";
+        Token token = Token.builder()
+                .id(1L)
+                .token(tokenValue)
+                .status(TokenStatus.PENDING)
+                .build();
+        tokenRepository.save(token);
+
+        // When
+        //Thread.sleep(6000); // 스케줄러 실행 대기
+        queueScheduler.processQueue();
+
+        // Then
+        Token updatedToken = tokenRepository.findByToken(tokenValue).orElse(null);
+        assertThat(updatedToken).isNotNull();
+        assertThat(updatedToken.getStatus()).isEqualTo(TokenStatus.ACTIVE);
+    }
+
+    @Test
+    void 스케줄러_비활성화된_토큰_만료_성공() throws InterruptedException {
+        // Given
+        String tokenValue = "valid-token";
+        Token token = Token.builder()
+                .id(1L)
+                .token(tokenValue)
+                .status(TokenStatus.ACTIVE)
+                .lastRequestAt(LocalDateTime.now().minusMinutes(15)) // 마지막 요청으로부터 응답 15분 지남
+                .build();
+        tokenRepository.save(token);
+
+        // When
+        // Thread.sleep(6000); // 스케줄러 실행 대기
+        queueScheduler.expireInactiveActiveTokens();
+
+        // Then
+        Token expiredToken = tokenRepository.findByToken(tokenValue).orElse(null);
+        assertThat(expiredToken).isNotNull();
+        assertThat(expiredToken.getStatus()).isEqualTo(TokenStatus.EXPIRED);
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/api/token/TokenServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/token/TokenServiceTest.java
@@ -1,0 +1,175 @@
+package kr.hhplus.be.server.api.token;
+
+import kr.hhplus.be.server.api.common.exception.CustomException;
+import kr.hhplus.be.server.api.common.type.TokenStatus;
+import kr.hhplus.be.server.api.token.application.service.TokenService;
+import kr.hhplus.be.server.api.token.domain.entity.Token;
+import kr.hhplus.be.server.api.token.domain.repository.TokenRepository;
+import kr.hhplus.be.server.api.token.domain.validator.TokenValidator;
+import kr.hhplus.be.server.api.token.exception.TokenErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class TokenServiceTest {
+
+    TokenService tokenService;
+
+    TokenRepository tokenRepository;
+
+    TokenValidator tokenValidator;
+
+    //Validator로 인해 직접 주입
+    @BeforeEach
+    void setUp() {
+        tokenValidator = new TokenValidator();
+        tokenRepository = mock(TokenRepository.class);
+        tokenService = new TokenService(tokenRepository, tokenValidator);
+    }
+
+    @Test
+    void 대기열_토큰_발급_성공() {
+        // given: 테스트 데이터와 Mock 동작 정의
+        Long userId = 1L;
+
+        // Token 객체 생성
+        Token token = Token.builder()
+                .id(1L)
+                .userId(userId)
+                .build();
+
+        //tokenRepository.save(any(Token.class))는 save 메서드가 호출될 때 Token 객체를 어떤 값으로 전달하든(즉, "any" Token 객체로) 동작을 설정하는 의미
+        when(tokenRepository.save(any(Token.class))).thenReturn(token);
+
+        // when
+        Token result = tokenService.issueToken(userId);
+
+        // then
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        assertEquals(userId, result.getUserId());
+        verify(tokenRepository, times(1)).save(any(Token.class));
+
+    }
+
+    @Test
+    void 존재하지_않는_토큰_검증_실패() {
+        // Given
+        String tokenValue = "non-existent-token";
+
+        when(tokenRepository.findByToken(tokenValue)).thenReturn(Optional.empty());
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> tokenService.validateAndExtendToken(tokenValue));
+        assertEquals(TokenErrorCode.TOKEN_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void 유효한_토큰으로_검증_및_만료시간_연장_성공() {
+        // given
+        String tokenValue = "valid-token";
+        Token token = Token.builder()
+                .token(tokenValue)
+                .status(TokenStatus.ACTIVE)
+                .expiredAt(LocalDateTime.now().plusMinutes(5)) // 초기 만료 시간 설정
+                .maxExpiredAt(LocalDateTime.now().plusMinutes(30)) // 최대 만료 시간 설정
+                .build();
+
+        when(tokenRepository.findByToken(tokenValue)).thenReturn(Optional.of(token));
+
+        // when
+        tokenService.validateAndExtendToken(tokenValue);
+
+        // then
+        assertNotNull(token.getExpiredAt());
+        assertTrue(token.getExpiredAt().isBefore(token.getMaxExpiredAt()));
+        verify(tokenRepository, times(1)).save(token);
+    }
+
+
+    @Test
+    void 토큰이_존재하지_않음() {
+        // given
+        String tokenValue = "non-existent-token";
+        when(tokenRepository.findByToken(tokenValue)).thenReturn(Optional.empty());
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> tokenService.validateAndExtendToken(tokenValue));
+        assertEquals(TokenErrorCode.TOKEN_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void 토큰_상태가_ACTIVE가_아님() {
+        // given
+        String tokenValue = "pending-token";
+        Token token = Token.builder()
+                .token(tokenValue)
+                .status(TokenStatus.PENDING) // 상태가 PENDING
+                .expiredAt(LocalDateTime.now().plusMinutes(5))
+                .build();
+
+        when(tokenRepository.findByToken(tokenValue)).thenReturn(Optional.of(token));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> tokenService.validateAndExtendToken(tokenValue));
+        assertEquals(TokenErrorCode.TOKEN_NOT_ACTIVE, exception.getErrorCode());
+    }
+
+    @Test
+    void 토큰_만료됨() {
+        // given
+        String tokenValue = "expired-token";
+        Token token = Token.builder()
+                .token(tokenValue)
+                .status(TokenStatus.ACTIVE)
+                .expiredAt(LocalDateTime.now().minusMinutes(1)) // 만료된 상태
+                .build();
+
+        when(tokenRepository.findByToken(tokenValue)).thenReturn(Optional.of(token));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> tokenService.validateAndExtendToken(tokenValue));
+        assertEquals(TokenErrorCode.TOKEN_EXPIRED, exception.getErrorCode());
+    }
+
+    @Test
+    void expiredAt이_null인_토큰_검증_실패() {
+        // given
+        String tokenValue = "pending-token";
+        Token token = Token.builder()
+                .token(tokenValue)
+                .status(TokenStatus.ACTIVE)
+                .expiredAt(null) // 대기열 통과하지 않음
+                .build();
+
+        when(tokenRepository.findByToken(tokenValue)).thenReturn(Optional.of(token));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> tokenService.validateAndExtendToken(tokenValue));
+        assertEquals(TokenErrorCode.TOKEN_NOT_PASSED_QUEUE, exception.getErrorCode());
+    }
+
+    @Test
+    void expiredAt이_null인_상태에서_만료시간_연장_실패() {
+        // given
+        Token token = Token.builder()
+                .token("pending-token")
+                .status(TokenStatus.ACTIVE)
+                .expiredAt(null) // 만료 시간이 설정되지 않음
+                .build();
+
+        // when & then
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> token.extendExpiration(5));
+        assertEquals("Token has not passed the queue yet", exception.getMessage());
+    }
+}
+


### PR DESCRIPTION

## 🔗[Swagger DOC 바로가기](https://cheese-2.gitbook.io/hh_crs_doc/swagger/api)


### **커밋 링크**
**1) 사용자 대기열 토큰 기능 개발** : 09e2300be21bc728856fb3347fe7e7b1d14027e6
   - 테스트 코드 : 8f8e5afc5d83832c53062087353a1d2b3b5545a6
   - 내용
     - 사용자 대기열을 저장하고 토큰을 발급
     - 스케쥴러를 통해 대기열 관리
     - 토큰 발급 받을 시에는 만료기간을 지정하지 않으며, ``PENDING`` 상태로 지정
     - 대기열을 통과한 이후부터 만료기간(``expired_at``)이 지정되며 상태 값은 ``ACTIVE``로 변경됨
     - 요청 마다 5분씩 갱신되나, 최대 만료기간(``max_expired_at``)은 넘지 않도록 제한됨
     - ``ACTIVE``상태인 토큰들의 마지막 요청시간을 조회하여, 10분 이상 요청이 없는 토큰은 ``EXPIRED``로 상태 값 변경

**2) 콘서트 기능 개발** : f4364410a5cf570aab6d6b36d514b34deee94662
   - 테스트 코드 : a7d5de499e13879441a554369bad08eaab56a993
   - 내용
     - 콘서트의 예매 가능한 날짜와 좌석 조회
     - 콘서트의 매진 여부를 확인하며, 예약된 좌석인지 좌석 상태 확인
     - 예약 요청이 들어올 경우 좌석 상태를 ``RESERVED``로 변경
     - (예약이 가능한)남은 좌석 개수 확인하여 콘서트 매진 처리(``is_sold_out``)
     
**3) 좌석 예약 및 결제 기능 개발** : (예약) f6f9f3c6fa3b2447e499f3a90d3b4022a29dc85e , (결제) 0ece89f9c0e81ce5d40ef0442f98a8a75cbe51a7
   - 테스트 코드 : b3dfc1b57f21bab38edbd6fdcd89708a49ae9f67
   - 내용
     - 조회한 좌석 예약 요청
     - 상태가 확인된(``AVALIABLE``) 좌석에 대한 예약 생성
     - 중복 예약인지(이미 예약이 되었는지) 확인하며, 예약처리 진행함 (validation은 concert에서 좌석을 찾을 때 검증)
     - 예약된 좌석을 결제할 때, 예약 상태를 우선적으로 확인(``PENDING``상태로 되어있어야 함)
     - 사용자의 잔액 확인 후 부족한 잔액만 충전하여 기록 저장(예약에는 실제로 결제한 금액이 지정됨)
     - 결제된 예약은 ``PAID`` 처리됨
     
**4) 잔액 관리 기능 개발** : 389a530367c40cc08c9f926200f63a923cd7ff4c
   - 테스트 코드 : 5ea7f956246be00823eb22b74297323bf0577378
   - 내용
     - 잔액 조회 및 충전
     - 사용자 잔액 정보가 없을 경우 0으로 반환
     - 사용자 잔액을 충전 후 없으면 새로운 객체 생성 후 충전하여 변경된 정보를 반환