### PR TITLE
Kafka 연동 및 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,10 @@ dependencies {
 	// Jakarta Bean Validation API
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 
+	// Kafka
+	implementation("org.springframework.kafka:spring-kafka:3.3.1")
+	testImplementation("org.springframework.kafka:spring-kafka-test")
+
 }
 
 tasks.withType<Test> {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,102 +11,125 @@ services:
       - MYSQL_PASSWORD=application
       - MYSQL_DATABASE=hhplus
       - MYSQL_ROOT_HOST=%
-#      - MYSQL_TCP_PORT=3306  # MySQL이 3306 포트를 강제 사용하도록 설정
-#    command: --port=3306  # MySQL 실행 시 3306 포트를 강제 사용
+    #      - MYSQL_TCP_PORT=3306  # MySQL이 3306 포트를 강제 사용하도록 설정
+    #    command: --port=3306  # MySQL 실행 시 3306 포트를 강제 사용
     volumes:
+      - ./data/mysql/my.cnf:/etc/mysql/my.cnf
       - mysql_data:/var/lib/mysql
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       interval: 10s
       retries: 5
-      start_period: 30s
+#      start_period: 30s
 
-  mysql-init:
-    image: mysql:8.0
-    depends_on:
-      mysql:
-        condition: service_healthy
-    volumes:
-      - ./data/initdb:/docker-entrypoint-initdb.d
-    entrypoint: ["/bin/sh", "-c"]
-    command:
-      - |
-        echo "Waiting for MySQL to be ready...";
-        sleep 10;
-        echo "Running initial schema setup...";
-        mysql -h mysql -P 3306 -uapplication -papplication -Dhhplus --connect-timeout=30 < /docker-entrypoint-initdb.d/0_schema.sql;
-        echo "Schema setup complete.";
-        echo "Running initial bulk data scripts...";
-        mysql -h mysql -P 3306 -uapplication -papplication -Dhhplus < /docker-entrypoint-initdb.d/1_bulk_data.sql;
-        echo "MySQL initialization complete.";
-    restart: "no"
+  #  mysql-init:
+  #    image: mysql:8.0
+  #    depends_on:
+  #      mysql:
+  #        condition: service_healthy
+  #    volumes:
+  #      - ./data/initdb:/docker-entrypoint-initdb.d
+  #    entrypoint: ["/bin/sh", "-c"]
+  #    command:
+  #      - |
+  #        echo "Waiting for MySQL to be ready...";
+  #        sleep 10;
+  #        echo "Running initial schema setup...";
+  #        mysql -h mysql -P 3306 -uapplication -papplication -Dhhplus --connect-timeout=30 < /docker-entrypoint-initdb.d/0_schema.sql;
+  #        echo "Schema setup complete.";
+  #        echo "Running initial bulk data scripts...";
+  #        mysql -h mysql -P 3306 -uapplication -papplication -Dhhplus < /docker-entrypoint-initdb.d/1_bulk_data.sql;
+  #        echo "MySQL initialization complete.";
+  #    restart: "no"
 
-  influxdb:
-    image: influxdb:1.8
-    container_name: influxdb
+  redis:
+    image: redis:latest
+    container_name: redis
     ports:
-      - "8086:8086"
+      - "6379:6379"
     volumes:
-      - ./influxdb:/var/lib/influxdb
-    environment:
-      - INFLUXDB_DB=hhplus
-      - INFLUXDB_ADMIN_USER=admin
-      - INFLUXDB_ADMIN_PASSWORD=admin123
+      - ./data/redis:/data
 
-  grafana:
-    image: grafana/grafana
-    container_name: grafana
-    ports:
-      - "3000:3000"
-    restart: always
-    volumes:
-      - ./grafana:/var/lib/grafana
-    environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin
-      - GF_USERS_ALLOW_SIGN_UP=false
-    depends_on:
-      - influxdb
-
-  k6:
-    image: grafana/k6
-    container_name: k6-
-    volumes:
-      - ./k6:/scripts
-    working_dir: /scripts
-    entrypoint: ["k6", "run", "--out", "influxdb=http://influxdb:8086/hhplus", "/scripts/script.js"]
-    depends_on:
-      - influxdb
-    networks:
-      - default
-
-#  prometheus:
-#    image: prom/prometheus
-#    container_name: prometheus
+#  influxdb:
+#    image: influxdb:1.8
+#    container_name: influxdb
 #    ports:
-#      - "9090:9090"
+#      - "8086:8086"
+#    volumes:
+#      - ./influxdb:/var/lib/influxdb
+#    environment:
+#      - INFLUXDB_DB=hhplus
+#      - INFLUXDB_ADMIN_USER=admin
+#      - INFLUXDB_ADMIN_PASSWORD=admin123
+#
+#  grafana:
+#    image: grafana/grafana
+#    container_name: grafana
+#    ports:
+#      - "3000:3000"
 #    restart: always
 #    volumes:
-#      - ./prometheus.yml:/etc/prometheus/prometheus.yml
-#
-#  mysql-exporter:
-#    container_name: mysql-exporter
-#    image: prom/mysqld-exporter
-#    command:
-#      - "--mysqld.username=application:application"
-#      - "--mysqld.address=mysql:3307"
-#    ports:
-#      - "9104:9104"
+#      - ./grafana:/var/lib/grafana
+#    environment:
+#      - GF_SECURITY_ADMIN_USER=admin
+#      - GF_SECURITY_ADMIN_PASSWORD=admin
+#      - GF_USERS_ALLOW_SIGN_UP=false
 #    depends_on:
-#      - mysql
-
-#  redis:
-#    image: redis:latest
-#    container_name: redis
-#    ports:
-#      - "6379:6379"
+#      - influxdb
+#
+#  k6:
+#    image: grafana/k6
+#    container_name: k6-
 #    volumes:
-#      - ./data/redis:/data
+#      - ./k6:/scripts
+#    working_dir: /scripts
+#    entrypoint: ["k6", "run", "--out", "influxdb=http://influxdb:8086/hhplus", "/scripts/script.js"]
+#    depends_on:
+#      - influxdb
+#    networks:
+#      - default
+
+  #  prometheus:
+  #    image: prom/prometheus
+  #    container_name: prometheus
+  #    ports:
+  #      - "9090:9090"
+  #    restart: always
+  #    volumes:
+  #      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+  #
+  #  mysql-exporter:
+  #    container_name: mysql-exporter
+  #    image: prom/mysqld-exporter
+  #    command:
+  #      - "--mysqld.username=application:application"
+  #      - "--mysqld.address=mysql:3307"
+  #    ports:
+  #      - "9104:9104"
+  #    depends_on:
+  #      - mysql
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
 volumes:
   mysql_data:

--- a/src/main/java/kr/hhplus/be/server/api/common/config/KafkaConfig.java
+++ b/src/main/java/kr/hhplus/be/server/api/common/config/KafkaConfig.java
@@ -1,0 +1,41 @@
+package kr.hhplus.be.server.api.common.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-group");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/application/event/PaymentFailedEvent.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/application/event/PaymentFailedEvent.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.api.reservation.application.event;
+
+import lombok.Getter;
+
+@Getter
+public class PaymentFailedEvent {
+    private final Long reservationId;
+    private final Long userId;
+    private final Long paymentAmount;
+
+    public PaymentFailedEvent(Long reservationId, Long userId, Long paymentAmount) {
+        this.reservationId = reservationId;
+        this.userId = userId;
+        this.paymentAmount = paymentAmount;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/application/event/handler/PaymentCompensationEventHandler.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/application/event/handler/PaymentCompensationEventHandler.java
@@ -1,0 +1,29 @@
+package kr.hhplus.be.server.api.reservation.application.event.handler;
+
+import kr.hhplus.be.server.api.concert.application.service.ConcertService;
+import kr.hhplus.be.server.api.reservation.application.event.PaymentFailedEvent;
+import kr.hhplus.be.server.api.reservation.application.service.ReservationService;
+import kr.hhplus.be.server.api.token.application.service.TokenService;
+import kr.hhplus.be.server.api.user.application.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentCompensationEventHandler {
+
+    private final ReservationService reservationService;
+    private final UserService userService;
+    private final ConcertService concertService;
+    private final TokenService tokenService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePaymentFailedEvent(PaymentFailedEvent event){
+        // 보상 로직 실행(각 서비스의 보상 method 호출) => 토큰은 처리 안함
+        userService.refundPayment(event.getUserId(), event.getPaymentAmount());
+        reservationService.cancelResrvation(event.getReservationId());
+        concertService.cancelSeatPayment(event.getReservationId());
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/application/facade/ReservationFacade.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/application/facade/ReservationFacade.java
@@ -3,22 +3,22 @@ package kr.hhplus.be.server.api.reservation.application.facade;
 import kr.hhplus.be.server.api.common.exception.CustomException;
 import kr.hhplus.be.server.api.common.lock.annotation.RedisLock;
 import kr.hhplus.be.server.api.concert.application.dto.response.ConcertSeatResult;
+import kr.hhplus.be.server.api.concert.application.service.ConcertService;
 import kr.hhplus.be.server.api.concert.exception.SeatErrorCode;
+import kr.hhplus.be.server.api.reservation.application.dto.command.PaymentCommand;
 import kr.hhplus.be.server.api.reservation.application.dto.command.ReservationCommand;
 import kr.hhplus.be.server.api.reservation.application.dto.result.PaymentResult;
+import kr.hhplus.be.server.api.reservation.application.dto.result.ReservationResult;
 import kr.hhplus.be.server.api.reservation.application.event.ConcertSeatPaidEvent;
 import kr.hhplus.be.server.api.reservation.application.event.ConcertSeatReservedEvent;
-import kr.hhplus.be.server.api.token.application.service.TokenService;
-import kr.hhplus.be.server.api.user.application.service.UserService;
-import kr.hhplus.be.server.api.concert.application.service.ConcertService;
-import kr.hhplus.be.server.api.reservation.application.dto.command.PaymentCommand;
-import kr.hhplus.be.server.api.reservation.application.dto.result.ReservationResult;
+import kr.hhplus.be.server.api.reservation.application.event.PaymentFailedEvent;
 import kr.hhplus.be.server.api.reservation.application.service.ReservationService;
 import kr.hhplus.be.server.api.reservation.domain.entity.Reservation;
+import kr.hhplus.be.server.api.token.application.service.TokenService;
+import kr.hhplus.be.server.api.user.application.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -35,7 +35,7 @@ public class ReservationFacade {
      * - ReservationService를 통해 예약 정보 생성
      */
     @RedisLock(prefix = "seat:", key = "#reservationCmd.seatId")
-    @Transactional
+//    @Transactional // 예약은 기존 로직대로 처리(필요 시 독립 트랜잭션 적용 예정)
     public ReservationResult reserveSeat(ReservationCommand reservationCmd) {
         // 1. 좌석 상태 확인
         ConcertSeatResult seatResult = concertService.reserveSeat(reservationCmd.seatId());
@@ -63,57 +63,64 @@ public class ReservationFacade {
      * - ReservationService를 통해 상태 업데이트
      */
     @RedisLock(prefix = "seat:", key = "#paymentCmd.seatId")
-    @Transactional
     public PaymentResult payReservation(PaymentCommand paymentCmd) {
-        // 1. 예약 조회
-        Reservation reservation = reservationService.findById(paymentCmd.reservationId());
+        try{
+            // 1. 예약 조회 (별도 트랜잭션: ReservationService.findById는 REQUIRES_NEW 적용)
+            Reservation reservation = reservationService.findById(paymentCmd.reservationId());
+            if (reservation == null) {
+                throw new CustomException(SeatErrorCode.SEAT_NOT_RESERVED);
+            }
 
-        if (reservation == null) {
-            throw new CustomException(SeatErrorCode.SEAT_NOT_RESERVED);
+            // 2. 예약 유효성 검증(금액 및 예약상태)
+            reservation.validate();
+            Long seatPrice = reservation.getPrice();
+
+            // 3. 결제 처리 (및 잔액) - 별도 트랜잭션: UserService.processPayment
+            Long remainingBalance = userService.processPayment(paymentCmd.userId(), paymentCmd.paymentAmount());
+
+            // 4. 실제 결제 금액 계산
+            Long paidAmount = seatPrice - remainingBalance + paymentCmd.paymentAmount();
+
+            // 5. 좌석 상태 변경 및 일정 확인 - 별도 트랜잭션: ConcertService.payForSeat
+            ConcertSeatResult seatResult = concertService.payForSeat(reservation.getSeatId());
+
+            // 6. 예약 상태 및 결제 정보 업데이트 - 별도 트랜잭션: ReservationService.updateReservation
+            reservation.pay(paidAmount);
+            reservationService.updateReservation(reservation);
+
+            // 7. 대기열 토큰 만료 처리 - 별도 트랜잭션: TokenService.getTokenIdByUserId / expireToken
+            Long tokenId = tokenService.getTokenIdByUserId(reservation.getUserId());
+            if (tokenId != null) {
+                tokenService.expireToken(tokenId);
+            }
+
+            // 8. 좌석 결제 완료 이벤트 발행
+            eventPublisher.publishEvent(new ConcertSeatPaidEvent(
+                    reservation.getId(),
+                    reservation.getConcertId(),
+                    reservation.getSeatNumber(),
+                    reservation.getUserId(),
+                    seatPrice,
+                    paidAmount
+            ));
+
+            // 9. PaymentResult 생성 및 반환
+            return new PaymentResult(
+                    reservation.getId(),
+                    seatResult.status(),
+                    remainingBalance,
+                    seatPrice,
+                    paidAmount,
+                    reservation.getPaidAt()
+            );
+        }catch(Exception ex){
+            // 실패 발생 시 보상 이벤트 발행
+            eventPublisher.publishEvent(new PaymentFailedEvent(
+                    paymentCmd.reservationId(),
+                    paymentCmd.userId(),
+                    paymentCmd.paymentAmount()
+            ));
+            throw ex;
         }
-
-        // 2. 예약 유효성 검증(금액 및 예약상태)
-        reservation.validate();
-
-        // 3. 결제 처리 (및 잔액)
-        Long seatPrice = reservation.getPrice();
-        Long remainingBalance = userService.processPayment(paymentCmd.userId(), paymentCmd.paymentAmount());
-
-        // 4. 실제 결제 금액 계산
-        Long paidAmount = seatPrice - remainingBalance + paymentCmd.paymentAmount();
-
-        // 5. 좌석 상태 변경 및 일정 확인
-        ConcertSeatResult seatResult = concertService.payForSeat(reservation.getSeatId());
-
-        // 6. 예약 상태 및 결제 정보 업데이트
-        reservation.pay(paidAmount);
-        reservationService.updateReservation(reservation);
-
-        // 7. 대기열 토큰 만료
-        // userId를 이용해 tokenId를 조회한 후, 무조건 토큰 만료 처리
-        Long tokenId = tokenService.getTokenIdByUserId(reservation.getUserId());
-        if (tokenId != null) {
-            tokenService.expireToken(tokenId);
-        }
-
-        // 8. 좌석 결제 완료 이벤트 발행
-        eventPublisher.publishEvent(new ConcertSeatPaidEvent(
-                reservation.getId(),
-                reservation.getConcertId(),
-                reservation.getSeatNumber(),
-                reservation.getUserId(),
-                seatPrice,
-                paidAmount
-        ));
-
-        // 9. PaymentResult 생성 및 반환
-        return new PaymentResult(
-                reservation.getId(),
-                seatResult.status(),
-                remainingBalance,
-                seatPrice,  // 좌석 가격
-                paidAmount,  // 실제 결제 금액
-                reservation.getPaidAt()
-        );
     }
 }

--- a/src/main/java/kr/hhplus/be/server/api/reservation/domain/entity/Reservation.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/domain/entity/Reservation.java
@@ -63,8 +63,18 @@ public class Reservation {
      */
     public void pay(Long amount) {
         this.status = ReservationStatus.PAID;
-        this.price = amount;
+        this.price = amount; //예약할 때 지불한 금액을 의미
         this.paidAt = LocalDateTime.now();
+    }
+
+    /**
+     * 예약 취소
+     */
+    public void cancel() {
+        this.status = ReservationStatus.PENDING;
+        this.expiredAt = null;
+        this.price = null;
+        this.paidAt = null;
     }
 
     public void validate() {

--- a/src/main/java/kr/hhplus/be/server/api/user/domain/entity/User.java
+++ b/src/main/java/kr/hhplus/be/server/api/user/domain/entity/User.java
@@ -44,4 +44,5 @@ public class User {
         }
         this.balance -= amount;
     }
+
 }

--- a/src/main/java/kr/hhplus/be/server/api/user/exception/UserErrorCode.java
+++ b/src/main/java/kr/hhplus/be/server/api/user/exception/UserErrorCode.java
@@ -1,0 +1,21 @@
+package kr.hhplus.be.server.api.user.exception;
+
+import kr.hhplus.be.server.api.common.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum UserErrorCode implements ErrorCode {
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자 정보를 찾을 수 없습니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String name;
+    private final String message;
+
+    UserErrorCode(HttpStatus httpStatus, String name, String message) {
+        this.httpStatus = httpStatus;
+        this.name = name;
+        this.message = message;
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/api/common/kafka/KafkaIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/common/kafka/KafkaIntegrationTest.java
@@ -39,7 +39,7 @@ public class KafkaIntegrationTest {
         latch = new CountDownLatch(1);
         receivedMessage = null;
 
-        // ✅ Embedded Kafka가 완전히 실행될 시간을 줌
+        // Embedded Kafka가 완전히 실행될 시간을 줌
         Thread.sleep(3000);
     }
 
@@ -49,7 +49,7 @@ public class KafkaIntegrationTest {
      */
     @KafkaListener(topics = TOPIC, groupId = "test-group")
     public void consume(ConsumerRecord<String, String> record) {
-        System.out.println("📥 Received message: " + record.value());
+        System.out.println("Received message: " + record.value());
         this.receivedMessage = record.value();
         latch.countDown();
     }

--- a/src/test/java/kr/hhplus/be/server/api/common/kafka/KafkaIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/common/kafka/KafkaIntegrationTest.java
@@ -1,0 +1,92 @@
+package kr.hhplus.be.server.api.common.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@EmbeddedKafka(partitions = 1, topics = { "test-topic" })
+@EnableKafka
+@TestPropertySource(properties = {
+        "spring.kafka.bootstrap-servers=localhost:9092",  // Embedded Kafka의 기본 설정값 사용
+        "spring.kafka.consumer.auto-offset-reset=earliest",
+        "spring.kafka.producer.retries=5"  // 메시지 전송 실패 시 재시도하도록 설정
+})
+public class KafkaIntegrationTest {
+    private static final String TOPIC = "test-topic";
+
+    // 테스트마다 새로 초기화할 latch와 메시지
+    private CountDownLatch latch;
+    private String receivedMessage;
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @BeforeEach
+    public void setUp() throws InterruptedException {
+        latch = new CountDownLatch(1);
+        receivedMessage = null;
+
+        // ✅ Embedded Kafka가 완전히 실행될 시간을 줌
+        Thread.sleep(3000);
+    }
+
+    /**
+     * Kafka의 Consumer 역할을 수행하는 Listener
+     * 메시지를 받으면 receivedMessage를 설정하고 latch를 카운트다운
+     */
+    @KafkaListener(topics = TOPIC, groupId = "test-group")
+    public void consume(ConsumerRecord<String, String> record) {
+        System.out.println("📥 Received message: " + record.value());
+        this.receivedMessage = record.value();
+        latch.countDown();
+    }
+
+    /**
+     * 성공 테스트 : Producer가 전송한 메시지를 Consumer가 소비함
+     */
+    @Test
+    public void testSendMessage() throws InterruptedException {
+        String testMessage = "Kafka test message";
+
+        kafkaTemplate.send(TOPIC, testMessage);
+        kafkaTemplate.flush();
+
+        // 메시지 수신까지 대기 시간 설정
+        boolean messageReceived = latch.await(15, TimeUnit.SECONDS);
+
+        assertThat(messageReceived).isTrue();
+        assertThat(receivedMessage).isEqualTo(testMessage);
+    }
+
+    /**
+     * 실패 테스트 : Producer가 전송한 메시지를 Consumer가 다른 메시지를 소비한 것
+     * @throws InterruptedException
+     */
+    @Test
+    public void testSendFailMessage() throws InterruptedException {
+        String expectedMessage = "Kafka test message";
+        String wrongMessage = "Wrong message";
+
+        kafkaTemplate.send(TOPIC, wrongMessage);
+        kafkaTemplate.flush();
+
+        // 메시지 수신까지 대기 시간 설정
+        boolean messageReceived = latch.await(15, TimeUnit.SECONDS);
+
+        assertThat(messageReceived).isTrue();
+        assertThat(receivedMessage).isEqualTo(expectedMessage);
+    }
+}


### PR DESCRIPTION
## 🔗[Kafka 학습내용 정리 Doc](https://cheese-2.gitbook.io/kafka/)

### commit 링크
- kafka 연동 기본 설정 추가 및 연동 통합테스트 [d5aa6ab1e5be87e35d5831cc785fbb4a9fc6a6db]  
 
---

### 스프링과 연동해보기
```
docker exec -it kafka kafka-topics --create `
>>   --bootstrap-server localhost:9092 `
>>   --replication-factor 1 `
>>   --partitions 3 `
>>   --topic Concert-topic
```
![image](https://github.com/user-attachments/assets/8a58a898-7e60-4eea-9879-da6ebc5506c8)
```
docker exec -it kafka kafka-topics --list `
>>   --bootstrap-server localhost:9092
```
![image](https://github.com/user-attachments/assets/6e235fb8-66aa-49be-b83a-dd5fc754acd3)
```
docker exec -it kafka kafka-console-producer `
>>   --bootstrap-server localhost:9092 `
>>   --topic Concert-topic
```
![image](https://github.com/user-attachments/assets/e2c49daa-858c-4d25-a2af-3ef7d7763d25)

---

### KafkaIntegrationTest
- `@SpringBootTest`, `@EmbeddedKafka(partitions = 1, topics = { "test-topic" })`를 적용하여 Kafka 환경 설정
- `@KafkaListener`를 활용하여 특정 토픽의 메시지를 수신하는 Consumer를 구현
```
    /**
     * Kafka의 Consumer 역할을 수행하는 Listener
     * 메시지를 받으면 receivedMessage를 설정하고 latch를 카운트다운
     */
    @KafkaListener(topics = TOPIC, groupId = "test-group")
    public void consume(ConsumerRecord<String, String> record) {
        System.out.println("Received message: " + record.value());
        this.receivedMessage = record.value();
        latch.countDown();
    }
```
- CountDownLatch를 사용하여 메시지 수신을 대기하도록 설정
- 메시지를 전송(kafkaTemplate.send) 후, Consumer가 정상적으로 메시지를 받았는지 검증